### PR TITLE
Small tokenizer fix

### DIFF
--- a/ICSharpCode.NRefactory/CSharp/Parser/mcs/cs-tokenizer.cs
+++ b/ICSharpCode.NRefactory/CSharp/Parser/mcs/cs-tokenizer.cs
@@ -2630,6 +2630,7 @@ namespace Mono.CSharp
 		{
 			int c;
 			string_builder.Length = 0;
+			int start_col = Location.Column;
 
 			while (true){
 				c = get_char ();
@@ -2640,7 +2641,7 @@ namespace Mono.CSharp
 						continue;
 					}
 
-					val = new StringLiteral (string_builder.ToString (), Location);
+					val = new StringLiteral (string_builder.ToString (), new Location(ref_line, start_col));
 					return Token.LITERAL;
 				}
 
@@ -3508,4 +3509,3 @@ namespace Mono.CSharp
 		Error
 	}
 }
-


### PR DESCRIPTION
While trying out the NRefactory demo, I noticed that the start location for the StringLiteral "Hello, World" was bad. I tracked it down to the consume_string method in the tokenizer. When the StringLiteral was created, it was using the Location property which was current for the last character in the string, rather than the first.
