### PR TITLE
Allow user-defined conversions in operators in custom mscorlib.

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Resolver/CSharpResolver.cs
+++ b/ICSharpCode.NRefactory.CSharp/Resolver/CSharpResolver.cs
@@ -1257,7 +1257,7 @@ namespace ICSharpCode.NRefactory.CSharp.Resolver
 		{
 			if (c == Conversion.IdentityConversion)
 				return rr;
-			else if (rr.IsCompileTimeConstant && c != Conversion.None)
+			else if (rr.IsCompileTimeConstant && c != Conversion.None && !c.IsUserDefined)
 				return ResolveCast(targetType, rr);
 			else
 				return new ConversionResolveResult(targetType, rr, c, checkForOverflow);


### PR DESCRIPTION
I have a custom mscorlib, where char has an op_Implicit to convert it to string:

```
struct Char {
    public static implicit operator string(char ch) {
        return null;
    }
}
```

When I then write

`string s = "abc" + 'd'`

I get a conversion error.

The attached patch makes this scenario work (it almost did before, I think it was just bad luck that caused it not to), probably without breaking anything else (it doesn't break any tests, and I can't see how this could possibly affect anything with the standard mscorlib.
