### PR TITLE
Add attributes also to the "Attribute.Attrs" member, not only to Sections

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Parser/mcs/attribute.cs
+++ b/ICSharpCode.NRefactory.CSharp/Parser/mcs/attribute.cs
@@ -1133,13 +1133,15 @@ namespace Mono.CSharp {
 			Attrs.Add (a);
 			
 #if FULL_AST
-			Sections.Add (Attrs);
+			var s = new List<Attribute>();
+			s.Add(a);
+			Sections.Add (s);
 #endif
 		}
 
 		public Attributes (List<Attribute> attrs)
 		{
-			Attrs = attrs;
+			Attrs = new List<Attribute>(attrs);
 #if FULL_AST
 			Sections.Add (attrs);
 #endif


### PR DESCRIPTION
This conditional compilation caused the mcs embedded in NRefactory to not work. Perhaps it's not intended to (although I'm using it anyway), but if NRefactory's mcs ever gets merged into mono, this patch needs to be applied.
