### PR TITLE
More information about assembly references

### DIFF
--- a/ICSharpCode.NRefactory.Tests/Documentation/IDStringTests.cs
+++ b/ICSharpCode.NRefactory.Tests/Documentation/IDStringTests.cs
@@ -32,7 +32,7 @@ namespace ICSharpCode.NRefactory.Documentation
 	{
 		class IDStringTestProjectContent : DefaultUnresolvedAssembly, IDocumentationProvider
 		{
-			public IDStringTestProjectContent() : base("Test") {}
+			public IDStringTestProjectContent() : base("Test", null) {}
 			
 			public DocumentationComment GetDocumentation(IEntity entity)
 			{

--- a/ICSharpCode.NRefactory/TypeSystem/IAssembly.cs
+++ b/ICSharpCode.NRefactory/TypeSystem/IAssembly.cs
@@ -27,9 +27,9 @@ namespace ICSharpCode.NRefactory.TypeSystem
 	public interface IUnresolvedAssembly : IAssemblyReference
 	{
 		/// <summary>
-		/// Gets the assembly name (short name).
+		/// Gets the referenced assemblies.
 		/// </summary>
-		string AssemblyName { get; }
+		IEnumerable<IAssemblyReference> AssemblyReferences { get; }
 		
 		/// <summary>
 		/// Gets the list of all assembly attributes in the project.
@@ -49,6 +49,11 @@ namespace ICSharpCode.NRefactory.TypeSystem
 	
 	public interface IAssemblyReference
 	{
+		/// <summary>
+		/// Gets the assembly name (short name).
+		/// </summary>
+		string AssemblyName { get; }
+
 		/// <summary>
 		/// Resolves this assembly.
 		/// </summary>

--- a/ICSharpCode.NRefactory/TypeSystem/IProjectContent.cs
+++ b/ICSharpCode.NRefactory/TypeSystem/IProjectContent.cs
@@ -38,11 +38,6 @@ namespace ICSharpCode.NRefactory.TypeSystem
 		IEnumerable<IParsedFile> Files { get; }
 		
 		/// <summary>
-		/// Gets the referenced assemblies.
-		/// </summary>
-		IEnumerable<IAssemblyReference> AssemblyReferences { get; }
-		
-		/// <summary>
 		/// Gets the compiler settings object.
 		/// The concrete type of the settings object depends on the programming language used to implement this project.
 		/// </summary>

--- a/ICSharpCode.NRefactory/TypeSystem/Implementation/DefaultAssemblyReference.cs
+++ b/ICSharpCode.NRefactory/TypeSystem/Implementation/DefaultAssemblyReference.cs
@@ -26,7 +26,10 @@ namespace ICSharpCode.NRefactory.TypeSystem.Implementation
 	[Serializable]
 	public sealed class DefaultAssemblyReference : IAssemblyReference, ISupportsInterning
 	{
-		public static readonly IAssemblyReference CurrentAssembly = new CurrentAssemblyReference();
+		public static IAssemblyReference CurrentAssembly(string assemblyName) {
+			 return new CurrentAssemblyReference(assemblyName);
+		}
+
 		public static readonly IAssemblyReference Corlib = new DefaultAssemblyReference("mscorlib");
 		
 		string shortName;
@@ -56,6 +59,10 @@ namespace ICSharpCode.NRefactory.TypeSystem.Implementation
 		{
 			return shortName;
 		}
+
+		public string AssemblyName {
+			get { return shortName; }
+		}
 		
 		void ISupportsInterning.PrepareForInterning(IInterningProvider provider)
 		{
@@ -78,12 +85,22 @@ namespace ICSharpCode.NRefactory.TypeSystem.Implementation
 		[Serializable]
 		sealed class CurrentAssemblyReference : IAssemblyReference
 		{
+			private string assemblyName;
+
 			public IAssembly Resolve(ITypeResolveContext context)
 			{
 				IAssembly asm = context.CurrentAssembly;
 				if (asm == null)
 					throw new ArgumentException("A reference to the current assembly cannot be resolved in the compilation's global type resolve context.");
 				return asm;
+			}
+
+			public string AssemblyName {
+				get { return assemblyName; }
+			}
+
+			public CurrentAssemblyReference(string assemblyName) {
+				this.assemblyName = assemblyName;
 			}
 		}
 	}

--- a/ICSharpCode.NRefactory/TypeSystem/Implementation/DefaultUnresolvedAssembly.cs
+++ b/ICSharpCode.NRefactory/TypeSystem/Implementation/DefaultUnresolvedAssembly.cs
@@ -38,6 +38,7 @@ namespace ICSharpCode.NRefactory.TypeSystem.Implementation
 		string assemblyName;
 		IList<IUnresolvedAttribute> assemblyAttributes;
 		IList<IUnresolvedAttribute> moduleAttributes;
+		IList<IAssemblyReference> assemblyReferences;
 		Dictionary<FullNameAndTypeParameterCount, IUnresolvedTypeDefinition> typeDefinitions = new Dictionary<FullNameAndTypeParameterCount, IUnresolvedTypeDefinition>(FullNameAndTypeParameterCountComparer.Ordinal);
 		Dictionary<FullNameAndTypeParameterCount, ITypeReference> typeForwarders = new Dictionary<FullNameAndTypeParameterCount, ITypeReference>(FullNameAndTypeParameterCountComparer.Ordinal);
 		
@@ -51,13 +52,18 @@ namespace ICSharpCode.NRefactory.TypeSystem.Implementation
 			}
 		}
 		
-		public DefaultUnresolvedAssembly(string assemblyName)
+		public DefaultUnresolvedAssembly(string assemblyName, IList<IAssemblyReference> assemblyReferences)
 		{
 			if (assemblyName == null)
 				throw new ArgumentNullException("assemblyName");
 			this.assemblyName = assemblyName;
 			this.assemblyAttributes = new List<IUnresolvedAttribute>();
 			this.moduleAttributes = new List<IUnresolvedAttribute>();
+			this.assemblyReferences = FreezableHelper.FreezeList(assemblyReferences);
+		}
+
+		public IEnumerable<IAssemblyReference> AssemblyReferences {
+			get { return assemblyReferences; }
 		}
 		
 		public string AssemblyName {

--- a/ICSharpCode.NRefactory/TypeSystem/Implementation/MinimalCorlib.cs
+++ b/ICSharpCode.NRefactory/TypeSystem/Implementation/MinimalCorlib.cs
@@ -40,7 +40,7 @@ namespace ICSharpCode.NRefactory.TypeSystem.Implementation
 			return new SimpleCompilation(new DefaultSolutionSnapshot(), this);
 		}
 		
-		private MinimalCorlib() : base("corlib")
+		private MinimalCorlib() : base("corlib", null)
 		{
 			var types = new DefaultUnresolvedTypeDefinition[KnownTypeReference.KnownTypeCodeCount];
 			for (int i = 0; i < types.Length; i++) {


### PR DESCRIPTION
This patch adds an AssemblyReferences property to IUnresolvedAssembly, and also an AssemblyName property to IAssemblyReference. I ended up not needing this after writing the code, but I think it might be a good idea to have these properties, so here is code for it.
