### PR TITLE
Attempt to pass more detailed information about query expressions to the outside world

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/ICSharpCode.NRefactory.CSharp.csproj
+++ b/ICSharpCode.NRefactory.CSharp/ICSharpCode.NRefactory.CSharp.csproj
@@ -268,6 +268,7 @@
     <Compile Include="Resolver\NodeListResolveVisitorNavigator.cs" />
     <Compile Include="Resolver\OverloadResolution.cs" />
     <Compile Include="Resolver\OverloadResolutionErrors.cs" />
+    <Compile Include="Resolver\QueryExpressionLambda.cs" />
     <Compile Include="Resolver\ResolveAtLocation.cs" />
     <Compile Include="Resolver\ResolveVisitor.cs" />
     <Compile Include="Resolver\TypeInference.cs" />
@@ -385,12 +386,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.Targets" />
-  <ItemGroup>
-    <Folder Include="Completion\" />
-    <Folder Include="Refactoring\CodeIssues\" />
-    <Folder Include="Refactoring\CodeIssues\InconsistentNamingIssue\" />
-    <Folder Include="Refactoring\CodeActions\ExtractMethod\" />
-  </ItemGroup>
+  <ItemGroup />
   <ProjectExtensions>
     <MonoDevelop>
       <Properties>

--- a/ICSharpCode.NRefactory.CSharp/Resolver/QueryExpressionLambda.cs
+++ b/ICSharpCode.NRefactory.CSharp/Resolver/QueryExpressionLambda.cs
@@ -1,0 +1,133 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ICSharpCode.NRefactory.Semantics;
+using ICSharpCode.NRefactory.TypeSystem;
+using ICSharpCode.NRefactory.TypeSystem.Implementation;
+
+namespace ICSharpCode.NRefactory.CSharp.Resolver {
+	sealed class QueryExpressionLambda : LambdaResolveResult
+	{
+		internal class Parameter : IParameter {
+			public string Name { get { return name; } }
+			public DomRegion Region { get { return DomRegion.Empty; } }
+			public IType Type { get { return type; } }
+			public bool IsConst { get { return false; } }
+			public object ConstantValue { get { return null; } }
+			public IList<IAttribute> Attributes { get { return EmptyList<IAttribute>.Instance; } }
+			public bool IsRef { get { return false; } }
+			public bool IsOut { get { return false; } }
+			public bool IsParams { get { return false; } }
+			public bool IsOptional { get { return false; } }
+
+			private string name;
+			internal IType type;
+
+			public Parameter(string name) : this(name, SpecialType.UnknownType) {
+			}
+
+			public Parameter(string name, IType type) {
+				this.name = name;
+				this.type = type;
+			}
+
+			public override string ToString() {
+				return DefaultParameter.ToString(this);
+			}
+		}
+
+		readonly Parameter[] parameters;
+		readonly ResolveResult bodyExpression;
+		internal IType[] inferredParameterTypes;
+		IDictionary<IVariable, ResolveResult> rangeVariableMap;
+
+		public IDictionary<IVariable, ResolveResult> RangeVariableMap { get { return rangeVariableMap; } }
+			
+		public QueryExpressionLambda(int parameterCount, ResolveResult bodyExpression)
+		{
+			this.parameters = new Parameter[parameterCount];
+			for (int i = 0; i < parameterCount; i++) {
+				parameters[i] = new Parameter("x" + i);
+			}
+			this.bodyExpression = bodyExpression;
+		}
+
+		internal QueryExpressionLambda(IList<Parameter> parameters, ResolveResult bodyExpression, IDictionary<IVariable, ResolveResult> rangeVariableMap)
+		{
+			this.parameters = new Parameter[parameters.Count];
+			for (int i = 0; i < parameters.Count; i++) {
+				this.parameters[i] = parameters[i];
+			}
+			this.bodyExpression = bodyExpression;
+			this.rangeVariableMap = rangeVariableMap;
+		}
+			
+		public override IList<IParameter> Parameters {
+			get { return parameters; }
+		}
+			
+		public override Conversion IsValid(IType[] parameterTypes, IType returnType, CSharpConversions conversions)
+		{
+			if (parameterTypes.Length == parameters.Length) {
+				this.inferredParameterTypes = parameterTypes;
+				return new QueryExpressionLambdaConversion(parameterTypes);
+			} else {
+				return Conversion.None;
+			}
+		}
+			
+		public override bool IsAsync {
+			get { return false; }
+		}
+			
+		public override bool IsImplicitlyTyped {
+			get { return true; }
+		}
+			
+		public override bool IsAnonymousMethod {
+			get { return false; }
+		}
+			
+		public override bool HasParameterList {
+			get { return true; }
+		}
+			
+		public override ResolveResult Body {
+			get { return bodyExpression; }
+		}
+			
+		public override IType GetInferredReturnType(IType[] parameterTypes)
+		{
+			return bodyExpression.Type;
+		}
+			
+		public override string ToString()
+		{
+			return String.Format("[QueryExpressionLambda ({0}) => {1}]", String.Join(",", parameters.Select(p => p.Name)), bodyExpression);
+		}
+
+		internal void UpdateParametersFrom(QueryExpressionLambdaConversion conversion) {
+			for (int i = 0; i < parameters.Length; i++) {
+				parameters[i].type = conversion.ParameterTypes[i];
+			}
+		}
+
+		internal sealed class QueryExpressionLambdaConversion : Conversion
+		{
+			internal readonly IType[] ParameterTypes;
+			
+			public QueryExpressionLambdaConversion(IType[] parameterTypes)
+			{
+				this.ParameterTypes = parameterTypes;
+			}
+			
+			public override bool IsImplicit {
+				get { return true; }
+			}
+			
+			public override bool IsAnonymousFunctionConversion {
+				get { return true; }
+			}
+		}
+	}
+}

--- a/ICSharpCode.NRefactory.Demo/ICSharpCode.NRefactory.Demo.csproj
+++ b/ICSharpCode.NRefactory.Demo/ICSharpCode.NRefactory.Demo.csproj
@@ -72,7 +72,9 @@
     </Compile>
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SemanticTreeDialog.cs" />
+    <Compile Include="SemanticTreeDialog.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="SemanticTreeDialog.Designer.cs">
       <DependentUpon>SemanticTreeDialog.cs</DependentUpon>
     </Compile>

--- a/ICSharpCode.NRefactory.Demo/SemanticTreeDialog.cs
+++ b/ICSharpCode.NRefactory.Demo/SemanticTreeDialog.cs
@@ -18,6 +18,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Linq;
 using System.Reflection;
@@ -63,6 +64,13 @@ namespace ICSharpCode.NRefactory.Demo
 					if (child != null)
 						t.Nodes.Add(child);
 				}
+				return t;
+			} else if (obj.GetType().IsGenericType && obj.GetType().GetGenericTypeDefinition() == typeof(KeyValuePair<,>)) {
+				var t = new TreeNode(prefix + obj.ToString());
+				var key = obj.GetType().GetProperty("Key").GetValue(obj, null);
+				var value = obj.GetType().GetProperty("Value").GetValue(obj, null);
+				t.Nodes.Add(MakePropertyNode("Key", key.GetType(), key));
+				t.Nodes.Add(MakePropertyNode("Value", value.GetType(), value));
 				return t;
 			} else {
 				return new TreeNode(prefix + obj.ToString());

--- a/ICSharpCode.NRefactory/TypeSystem/AnonymousType.cs
+++ b/ICSharpCode.NRefactory/TypeSystem/AnonymousType.cs
@@ -70,6 +70,10 @@ namespace ICSharpCode.NRefactory.TypeSystem
 				return declaringType.GetHashCode() ^ unchecked(27 * this.Name.GetHashCode());
 			}
 		}
+
+		public IEnumerable<IUnresolvedProperty> GetUnresolvedProperties() {
+			return unresolvedProperties.Select(x => x);
+		}
 		
 		public override ITypeReference ToTypeReference()
 		{


### PR DESCRIPTION
NRefactory can currently resolve query experssions, in the sense that it can determine that `from a in arr select a + 1` is a call to `Enumerable.Select<int>`, but it does not report other interesting semantics, such as
`from a in arr let b = a + 1 select a + b` is transformed to something like `arr.Select(a => new { a, b = a + 1 }).Select(x => x.a + x.b)`

This commit is a POC of how an API for this could look. It contains the following changes:

1) The QueryExpressionLambda class has been made public. It has a property called `RangeVariableMap` that can be used to determine how to access local variables inside the lambda body.
2) The parameter types are correct in `QueryExpressionLambda`s.
3) The body for a lambda representing a let clause is something like `x => new { x, newValue = expr }` (it used to be meaningless).

This is by no means complete work, it's just intended as a starting point for a discussion of how the feature could look. It is also not implemented for the entire pattern, but as a test expression, it works for

```
    public void Main(string[] args)
    {
        var v = from a in args let i = int.Parse(a) let j = i + 1 where i > j select i + j;
    }
```

(and I also modified the demo program to show the relevant info).

What do you think?

(Btw, thanks for giving me credit as an author yesterday, it's a great honor).
