### PR TITLE
Two failing parser tests for query expression.

### DIFF
--- a/ICSharpCode.NRefactory.Tests/CSharp/Parser/Expression/QueryExpressionTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/Parser/Expression/QueryExpressionTests.cs
@@ -17,6 +17,7 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.Linq;
 using NUnit.Framework;
 
 namespace ICSharpCode.NRefactory.CSharp.Parser.Expression
@@ -180,7 +181,42 @@ select new { c.Name, o.OrderID, o.Total }",
 						}
 					}});
 		}
+
+		[Test]
+		public void ExpressionWithOrderByWithTwoOrderings()
+		{
+			ParseUtilCSharp.AssertExpression(
+				"from c in customers orderby c.Name, c.Address select c",
+				new QueryExpression {
+					Clauses = {
+						new QueryFromClause {
+							Identifier = "c",
+							Expression = new IdentifierExpression("customers")
+						},
+						new QueryOrderClause {
+							Orderings = {
+								new QueryOrdering {
+									Expression = new IdentifierExpression("c").Member("Name")
+								},
+								new QueryOrdering {
+									Expression = new IdentifierExpression("c").Member("Address")
+								}
+							}
+						},
+						new QuerySelectClause {
+							Expression = new IdentifierExpression("c")
+						}
+					}});
+		}
 		
+		[Test]
+		public void LocationOfWhere()
+		{
+			var expr = ParseUtilCSharp.ParseExpression<QueryExpression>("from c in customers where c.City == \"London\" select c");
+			var where = expr.Clauses.ElementAt(1);
+			Assert.That(where.StartLocation, Is.EqualTo(new TextLocation(1, 21)));
+		}
+
 		[Test]
 		public void ExpressionWithOrderByAndLet()
 		{


### PR DESCRIPTION
`orderby a, b` is parsed as `orderby a orderby b`

The location of where clauses is incorrect (the location of the clause is the same as the location of the expression).
