### PR TITLE
Failing query expression parser tests

### DIFF
--- a/ICSharpCode.NRefactory.Tests/CSharp/Parser/Expression/QueryExpressionTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/Parser/Expression/QueryExpressionTests.cs
@@ -218,6 +218,14 @@ select new { c.Name, o.OrderID, o.Total }",
 		}
 
 		[Test]
+		public void LocationOfOrderBy()
+		{
+			var expr = ParseUtilCSharp.ParseExpression<QueryExpression>("from c in customers orderby c.City select c");
+			var where = expr.Clauses.ElementAt(1);
+			Assert.That(where.StartLocation, Is.EqualTo(new TextLocation(1, 21)));
+		}
+
+		[Test]
 		public void ExpressionWithOrderByAndLet()
 		{
 			ParseUtilCSharp.AssertExpression(


### PR DESCRIPTION
`orderby a, b` is parsed as `orderby a orderby b`

The location of where and orderby clauses are incorrect (the location of the clause is the same as the location of the expression).
