### PR TITLE
Failing test for conversion of array to generic IList

### DIFF
--- a/ICSharpCode.NRefactory.Tests/CSharp/Resolver/ExplicitConversionsTest.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/Resolver/ExplicitConversionsTest.cs
@@ -491,5 +491,21 @@ class C {
 			Assert.IsTrue(rr.Conversion.IsUserDefined);
 			Assert.AreEqual("b", rr.Conversion.Method.Parameters.Single().Name);
 		}
+
+		[Test]
+		public void ExplicitArrayToGenericIList() {
+			var rr = Resolve<ConversionResolveResult>(@"
+using System.Collections.Generic;
+
+class B {}
+class D : B {}
+public class C {
+	public void M() {
+		B[] src = null;
+		IList<D> l = $(IList<D>)src$;
+	}
+}");
+			Assert.IsFalse(rr.IsError);
+		}
 	}
 }


### PR DESCRIPTION
Failing resolver test involving a conversion of an array to a generic IList.
