### PR TITLE
Sort usings code action

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/ICSharpCode.NRefactory.CSharp.csproj
+++ b/ICSharpCode.NRefactory.CSharp/ICSharpCode.NRefactory.CSharp.csproj
@@ -503,6 +503,7 @@
     <Compile Include="Refactoring\CodeIssues\RedundantWhereWithPredicateIssue.cs" />
     <Compile Include="Refactoring\CodeActions\ConvertToInitializer\AccessPath.cs" />
     <Compile Include="Refactoring\LocalReferenceFinder.cs" />
+    <Compile Include="Refactoring\CodeActions\SortUsingsAction.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ICSharpCode.NRefactory\ICSharpCode.NRefactory.csproj">

--- a/ICSharpCode.NRefactory.CSharp/Refactoring/CodeActions/SortUsingsAction.cs
+++ b/ICSharpCode.NRefactory.CSharp/Refactoring/CodeActions/SortUsingsAction.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ICSharpCode.NRefactory.Semantics;
+using ICSharpCode.NRefactory.TypeSystem;
+using ICSharpCode.NRefactory.TypeSystem.Implementation;
+
+namespace ICSharpCode.NRefactory.CSharp.Refactoring.CodeActions
+{
+	[ContextAction("Sort usings", Description = "Sorts usings by their origin and then alphabetically.")]
+	public class SortUsingsAction: ICodeActionProvider
+	{
+		public IEnumerable<CodeAction> GetActions(RefactoringContext context)
+		{
+			var usingNode = FindUsingNodeAtCursor(context);
+			if (usingNode == null)
+				yield break;
+
+			yield return new CodeAction(context.TranslateString("Sort usings"), script =>
+			{
+				var blocks = EnumerateUsingBlocks(context.RootNode);
+
+				foreach (var block in blocks)
+				{
+					var originalNodes = block.ToArray();
+					var sortedNodes = SortUsingBlock(originalNodes, context).ToArray();
+
+					for (var i = 0; i < originalNodes.Length; ++i)
+						script.Replace(originalNodes[i], sortedNodes[i].Clone());
+				}
+			});
+		}
+
+		private static AstNode FindUsingNodeAtCursor(RefactoringContext context)
+		{
+			// If cursor is inside using declaration
+			var locationAsIs = context.Location;
+			// If cursor is at end of line with using declaration
+			var locationLeft = new TextLocation(locationAsIs.Line, locationAsIs.Column - 1);
+
+			var possibleNodes = new[] { locationAsIs, locationLeft }
+				.Select(_ => context.RootNode.GetNodeAt(_, IsUsingDeclaration));
+			var usingNode = possibleNodes.Where(_ => _ != null).Distinct().SingleOrDefault();
+
+			return usingNode;
+		}
+
+		private static bool IsUsingDeclaration(AstNode node)
+		{
+			return node is UsingDeclaration || node is UsingAliasDeclaration;
+		}
+
+		private static IEnumerable<IEnumerable<AstNode>> EnumerateUsingBlocks(AstNode root)
+		{
+			var alreadyAddedNodes = new HashSet<AstNode>();
+
+			foreach (var child in root.Descendants)
+				if (IsUsingDeclaration(child) && !alreadyAddedNodes.Contains(child)) {
+					var blockNodes = EnumerateUsingBlockNodes(child);
+
+					alreadyAddedNodes.UnionWith(blockNodes);
+					yield return blockNodes;
+				}
+		}
+
+		private static IEnumerable<AstNode> EnumerateUsingBlockNodes(AstNode firstNode)
+		{
+			for (var node = firstNode; IsUsingDeclaration(node); node = node.NextSibling)
+				yield return node;
+		}
+
+		private static IEnumerable<AstNode> SortUsingBlock(IEnumerable<AstNode> nodes, RefactoringContext context)
+		{
+			var infos = nodes.Select(_ => new UsingInfo(_, context));
+			var orderedInfos = infos.OrderBy(_ => _, new UsingInfoComparer());
+			var orderedNodes = orderedInfos.Select(_ => _.Node);
+
+			return orderedNodes;
+		}
+
+
+		private sealed class UsingInfo
+		{
+			public AstNode Node { get; private set; }
+
+			public string Alias { get; private set; }
+			public string Name { get; private set; }
+
+			public bool IsAlias { get; private set; }
+			public bool IsAssembly { get; private set; }
+			public bool IsSystem { get; private set; }
+
+			public UsingInfo(AstNode node, RefactoringContext context)
+			{
+				var importAndAlias = GetImportAndAlias(node);
+
+				Node = node;
+
+				Alias = importAndAlias.Item2;
+				Name = importAndAlias.Item1.ToString();
+
+				IsAlias = Alias != null;
+
+				var result = context.Resolve(importAndAlias.Item1) as NamespaceResolveResult;
+				var mainSourceAssembly = result != null ? result.Namespace.ContributingAssemblies.First() : null;
+				var unresolvedAssembly = mainSourceAssembly != null ? mainSourceAssembly.UnresolvedAssembly : null;
+				IsAssembly = unresolvedAssembly is DefaultUnresolvedAssembly;
+
+				IsSystem = IsAssembly && Name.StartsWith("System");
+			}
+
+			private static Tuple<AstType, string> GetImportAndAlias(AstNode node)
+			{
+				var plainUsing = node as UsingDeclaration;
+				if (plainUsing != null)
+					return Tuple.Create(plainUsing.Import, (string)null);
+				
+				var aliasUsing = node as UsingAliasDeclaration;
+				if (aliasUsing != null)
+					return Tuple.Create(aliasUsing.Import, aliasUsing.Alias);
+
+				throw new InvalidOperationException(string.Format("Invalid using node: {0}", node));
+			}
+		}
+
+		private sealed class UsingInfoComparer: IComparer<UsingInfo>
+		{
+			public int Compare(UsingInfo x, UsingInfo y)
+			{
+				if (x.IsAlias != y.IsAlias)
+					return x.IsAlias && !y.IsAlias ? 1 : -1;
+				else if (x.IsAssembly != y.IsAssembly)
+					return x.IsAssembly && !y.IsAssembly ? -1 : 1;
+				else if (x.IsSystem != y.IsSystem)
+					return x.IsSystem && !y.IsSystem ? -1 : 1;
+				else if (x.Alias != y.Alias)
+					return Comparer<string>.Default.Compare(x.Alias, y.Alias);
+				else if (x.Name != y.Name)
+					return Comparer<string>.Default.Compare(x.Name, y.Name);
+				else
+					return 0;
+			}
+		}
+	}
+}

--- a/ICSharpCode.NRefactory.Tests/CSharp/CodeActions/SortUsingsTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/CodeActions/SortUsingsTests.cs
@@ -1,0 +1,109 @@
+using NUnit.Framework;
+using ICSharpCode.NRefactory.CSharp.Refactoring.CodeActions;
+
+namespace ICSharpCode.NRefactory.CSharp.CodeActions
+{
+	[TestFixture]
+	public class SortUsingsTests : ContextActionTestBase
+	{
+		[Test]
+		public void TestActiveWhenCursorAtUsing()
+		{
+			Test<SortUsingsAction>(@"using Sys$tem.Linq;
+using System;", @"using System;
+using System.Linq;");
+		}
+
+		[Test]
+		public void TestActiveWhenCursorBehindUsing()
+		{
+			Test<SortUsingsAction>(@"using System.Linq;$
+using System;", @"using System;
+using System.Linq;");
+		}
+
+		[Test]
+		public void TestInActiveWhenCursorOutsideUsings()
+		{
+			TestWrongContext<SortUsingsAction>(@"using System.Linq;
+using System;
+$");
+		}
+
+		[Test]
+		public void TestSortsAllUsingBlocksInFile()
+		{
+			Test<SortUsingsAction>(@"using $System.Linq;
+using System;
+
+namespace Foo
+{
+	using System.IO;
+	using System.Collections;
+}
+
+namespace Bar
+{
+	using System.IO;
+	using System.Runtime;
+	using System.Diagnostics;
+}", @"using System;
+using System.Linq;
+
+namespace Foo
+{
+	using System.Collections;
+	using System.IO;
+}
+
+namespace Bar
+{
+	using System.Diagnostics;
+	using System.IO;
+	using System.Runtime;
+}");
+		}
+
+		[Test]
+		public void TestAliasesGoesToTheEnd()
+		{
+			Test<SortUsingsAction>(@"$using Sys = System;
+using System;", @"using System;
+using Sys = System;");
+		}
+
+		[Test]
+		public void TestUnknownNamespacesGoesAfterKnownOnes()
+		{
+			Test<SortUsingsAction>(@"$using Foo;
+using System;", @"using System;
+using Foo;");
+		}
+
+		[Test]
+		public void TestMixedStuff()
+		{
+			Test<SortUsingsAction>(@"$using Foo;
+using System.Linq;
+using Sys = System;
+using System;
+using FooAlias = Foo;
+using Linq = System.Linq;", @"using System;
+using System.Linq;
+using Foo;
+using Linq = System.Linq;
+using Sys = System;
+using FooAlias = Foo;");
+		}
+
+		[Test]
+		public void TestPreservesEmptyLinesWhichIsInFactABug()
+		{
+			Test<SortUsingsAction>(@"$using System.Linq;
+
+using System;", @"using System;
+
+using System.Linq;");
+		}
+	}
+}

--- a/ICSharpCode.NRefactory.Tests/ICSharpCode.NRefactory.Tests.csproj
+++ b/ICSharpCode.NRefactory.Tests/ICSharpCode.NRefactory.Tests.csproj
@@ -360,6 +360,7 @@
     <Compile Include="CSharp\CodeIssues\ParameterCanBeDemotedIssue\SupportsIndexingCriterionTests.cs" />
     <Compile Include="CSharp\CodeActions\CreateBackingStoreTests.cs" />
     <Compile Include="CSharp\CodeIssues\RedundantWhereWithPredicateIssueTests.cs" />
+    <Compile Include="CSharp\CodeActions\SortUsingsTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Mono.Cecil\Mono.Cecil.csproj">


### PR DESCRIPTION
The basic stuff seems to work fine and is covered by tests though I have a couple of questions related to functionality and implementation.
1. Should this action work separately on usings at the begining of file and usings inside namespace declarations? So if I'd sort usings inside one namespace, all the others will remain untouched. Anyway, remove redundant usings action removes usings from any location so I've implemented sorting the same way.
2. Should namespaces from imported assemblies preceed those from the solution? For example, in tests should it be "NUnit, ICSharpCode" or "ICSharpCode, NUnit"?
3. Why remove redundant usings action is available when cursor is at the end of line with using declaration but "context.GetNode<UsingDeclaration>()" returns null in the same situation?
4. How to remove empty lines using the script object? Now my implementation just replaces nodes in the right order but I'd like to remove empty lines between them, because they may loose their meaning after reordering.
5. What's better way to add compound action "Sort and remove usings"?

Thanks!
