### PR TITLE
Resolver reports the wrong type when a dynamic call has only one applicable method.

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Resolver/CSharpInvocationResolveResult.cs
+++ b/ICSharpCode.NRefactory.CSharp/Resolver/CSharpInvocationResolveResult.cs
@@ -57,9 +57,10 @@ namespace ICSharpCode.NRefactory.CSharp.Resolver
 			bool isExpandedForm = false,
 			bool isDelegateInvocation = false,
 			IList<int> argumentToParameterMap = null,
-			IList<ResolveResult> initializerStatements = null
+			IList<ResolveResult> initializerStatements = null,
+			IType returnTypeOverride = null
 		)
-			: base(targetResult, member, arguments, initializerStatements)
+			: base(targetResult, member, arguments, initializerStatements, returnTypeOverride)
 		{
 			this.OverloadResolutionErrors = overloadResolutionErrors;
 			this.IsExtensionMethodInvocation = isExtensionMethodInvocation;

--- a/ICSharpCode.NRefactory.CSharp/Resolver/CSharpResolver.cs
+++ b/ICSharpCode.NRefactory.CSharp/Resolver/CSharpResolver.cs
@@ -1947,10 +1947,10 @@ namespace ICSharpCode.NRefactory.CSharp.Resolver
 				return new DynamicInvocationResolveResult(target, DynamicInvocationType.Invocation, AddArgumentNamesIfNecessary(arguments, argumentNames));
 			}
 			
+			bool isDynamic = arguments.Any(a => a.Type.Kind == TypeKind.Dynamic);
 			MethodGroupResolveResult mgrr = target as MethodGroupResolveResult;
-			Func<ResolveResult, ResolveResult> convert = x => x;
 			if (mgrr != null) {
-				if (arguments.Any(a => a.Type.Kind == TypeKind.Dynamic)) {
+				if (isDynamic) {
 					// If we have dynamic arguments, we need to represent the invocation as a dynamic invocation if there is more than one applicable method.
 					var or2 = CreateOverloadResolution(arguments, argumentNames, mgrr.TypeArguments.ToArray());
 					var applicableMethods = mgrr.MethodsGroupedByDeclaringType.SelectMany(m => m, (x, m) => new { x.DeclaringType, Method = m }).Where(x => OverloadResolution.IsApplicable(or2.AddCandidate(x.Method))).ToList();
@@ -1970,43 +1970,42 @@ namespace ICSharpCode.NRefactory.CSharp.Resolver
 						}
 						return new DynamicInvocationResolveResult(new MethodGroupResolveResult(actualTarget, mgrr.MethodName, l, mgrr.TypeArguments), DynamicInvocationType.Invocation, AddArgumentNamesIfNecessary(arguments, argumentNames));
 					}
-					else {
-						convert = x => x.Type.Kind == TypeKind.Dynamic ? x : Convert(x, SpecialType.Dynamic);
-					}
 				}
 
 				OverloadResolution or = mgrr.PerformOverloadResolution(compilation, arguments, argumentNames, checkForOverflow: checkForOverflow, conversions: conversions);
 				if (or.BestCandidate != null) {
 					if (or.BestCandidate.IsStatic && !or.IsExtensionMethodInvocation && !(mgrr.TargetResult is TypeResolveResult))
-						return convert(or.CreateResolveResult(new TypeResolveResult(mgrr.TargetType)));
+						return or.CreateResolveResult(new TypeResolveResult(mgrr.TargetType), returnTypeOverride: isDynamic ? SpecialType.Dynamic : null);
 					else
-						return convert(or.CreateResolveResult(mgrr.TargetResult));
+						return or.CreateResolveResult(mgrr.TargetResult, returnTypeOverride: isDynamic ? SpecialType.Dynamic : null);
 				} else {
 					// No candidate found at all (not even an inapplicable one).
 					// This can happen with empty method groups (as sometimes used with extension methods)
-					return convert(new UnknownMethodResolveResult(mgrr.TargetType, mgrr.MethodName, mgrr.TypeArguments, CreateParameters(arguments, argumentNames)));
+					return new UnknownMethodResolveResult(
+						mgrr.TargetType, mgrr.MethodName, mgrr.TypeArguments, CreateParameters(arguments, argumentNames));
 				}
 			}
 			UnknownMemberResolveResult umrr = target as UnknownMemberResolveResult;
 			if (umrr != null) {
-				return convert(new UnknownMethodResolveResult(umrr.TargetType, umrr.MemberName, umrr.TypeArguments, CreateParameters(arguments, argumentNames)));
+				return new UnknownMethodResolveResult(umrr.TargetType, umrr.MemberName, umrr.TypeArguments, CreateParameters(arguments, argumentNames));
 			}
 			UnknownIdentifierResolveResult uirr = target as UnknownIdentifierResolveResult;
 			if (uirr != null && CurrentTypeDefinition != null) {
-				return convert(new UnknownMethodResolveResult(CurrentTypeDefinition, uirr.Identifier, EmptyList<IType>.Instance, CreateParameters(arguments, argumentNames)));
+				return new UnknownMethodResolveResult(CurrentTypeDefinition, uirr.Identifier, EmptyList<IType>.Instance, CreateParameters(arguments, argumentNames));
 			}
 			IMethod invokeMethod = target.Type.GetDelegateInvokeMethod();
 			if (invokeMethod != null) {
 				OverloadResolution or = CreateOverloadResolution(arguments, argumentNames);
 				or.AddCandidate(invokeMethod);
-				return convert(new CSharpInvocationResolveResult(
+				return new CSharpInvocationResolveResult(
 					target, invokeMethod, //invokeMethod.ReturnType.Resolve(context),
 					or.GetArgumentsWithConversionsAndNames(), or.BestCandidateErrors,
 					isExpandedForm: or.BestCandidateIsExpandedForm,
 					isDelegateInvocation: true,
-					argumentToParameterMap: or.GetArgumentToParameterMap()));
+					argumentToParameterMap: or.GetArgumentToParameterMap(),
+					returnTypeOverride: isDynamic ? SpecialType.Dynamic : null);
 			}
-			return convert(ErrorResult);
+			return ErrorResult;
 		}
 		
 		List<IParameter> CreateParameters(ResolveResult[] arguments, string[] argumentNames)

--- a/ICSharpCode.NRefactory.CSharp/Resolver/OverloadResolution.cs
+++ b/ICSharpCode.NRefactory.CSharp/Resolver/OverloadResolution.cs
@@ -933,8 +933,11 @@ namespace ICSharpCode.NRefactory.CSharp.Resolver
 		/// <param name="initializerStatements">
 		/// Statements for Objects/Collections initializer.
 		/// <see cref="InvocationResolveResult.InitializerStatements"/>
+		/// <param name="returnTypeOverride">
+		/// If not null, use this instead of the ReturnType of the member as the type of the created resolve result.
 		/// </param>
-		public CSharpInvocationResolveResult CreateResolveResult(ResolveResult targetResolveResult, IList<ResolveResult> initializerStatements = null)
+		/// </param>
+		public CSharpInvocationResolveResult CreateResolveResult(ResolveResult targetResolveResult, IList<ResolveResult> initializerStatements = null, IType returnTypeOverride = null)
 		{
 			IParameterizedMember member = GetBestCandidateWithSubstitutedTypeArguments();
 			if (member == null)
@@ -949,7 +952,8 @@ namespace ICSharpCode.NRefactory.CSharp.Resolver
 				this.BestCandidateIsExpandedForm,
 				isDelegateInvocation: false,
 				argumentToParameterMap: this.GetArgumentToParameterMap(),
-				initializerStatements: initializerStatements);
+				initializerStatements: initializerStatements,
+				returnTypeOverride: returnTypeOverride);
 		}
 		#endregion
 	}

--- a/ICSharpCode.NRefactory.Tests/CSharp/Resolver/DynamicTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/Resolver/DynamicTests.cs
@@ -118,15 +118,13 @@ class TestClass {
 		var x = $this.SomeMethod(obj)$;
 	}
 }";
-			var rr = Resolve<ConversionResolveResult>(program);
-			Assert.That(rr.IsError, Is.False);
-			Assert.That(rr.Type.Kind, Is.EqualTo(TypeKind.Dynamic));
-			var irr = rr.Input as CSharpInvocationResolveResult;
-			Assert.That(irr, Is.Not.Null);
-			Assert.That(irr.Member.Name, Is.EqualTo("SomeMethod"));
-			Assert.That(((IParameterizedMember)irr.Member).Parameters.Count, Is.EqualTo(1));
-			Assert.That(irr.Arguments.Count, Is.EqualTo(1));
-			var cr = irr.Arguments[0] as ConversionResolveResult;
+			var rr = Resolve<CSharpInvocationResolveResult>(program);
+			Assert.That(rr, Is.Not.Null);
+			Assert.That(rr.Member.Name, Is.EqualTo("SomeMethod"));
+			Assert.That(rr.Type.Kind == TypeKind.Dynamic);
+			Assert.That(((IParameterizedMember)rr.Member).Parameters.Count, Is.EqualTo(1));
+			Assert.That(rr.Arguments.Count, Is.EqualTo(1));
+			var cr = rr.Arguments[0] as ConversionResolveResult;
 			Assert.That(cr, Is.Not.Null);
 			Assert.That(cr.Conversion.IsImplicit, Is.True);
 			Assert.That(cr.Conversion.IsDynamicConversion, Is.True);
@@ -316,9 +314,8 @@ class TestClass {
 		var x = $this.SomeMethod(obj)$;
 	}
 }";
-			var rr = Resolve<ConversionResolveResult>(program);
-			var irr = rr.Input;
-			Assert.That(irr.IsError, Is.True);
+			var rr = Resolve<CSharpInvocationResolveResult>(program);
+			Assert.That(rr.IsError, Is.True);
 		}
 
 		[Test]

--- a/ICSharpCode.NRefactory/Semantics/InvocationResolveResult.cs
+++ b/ICSharpCode.NRefactory/Semantics/InvocationResolveResult.cs
@@ -45,8 +45,9 @@ namespace ICSharpCode.NRefactory.Semantics
 		
 		public InvocationResolveResult(ResolveResult targetResult, IParameterizedMember member,
 		                               IList<ResolveResult> arguments = null,
-		                               IList<ResolveResult> initializerStatements = null)
-			: base(targetResult, member)
+		                               IList<ResolveResult> initializerStatements = null,
+		                               IType returnTypeOverride = null)
+			: base(targetResult, member, returnTypeOverride)
 		{
 			this.Arguments = arguments ?? EmptyList<ResolveResult>.Instance;
 			this.InitializerStatements = initializerStatements ?? EmptyList<ResolveResult>.Instance;

--- a/ICSharpCode.NRefactory/Semantics/MemberResolveResult.cs
+++ b/ICSharpCode.NRefactory/Semantics/MemberResolveResult.cs
@@ -38,8 +38,8 @@ namespace ICSharpCode.NRefactory.Semantics
 		readonly ResolveResult targetResult;
 		readonly bool isVirtualCall;
 		
-		public MemberResolveResult(ResolveResult targetResult, IMember member)
-			: base(member.EntityType == EntityType.Constructor ? member.DeclaringType : member.ReturnType)
+		public MemberResolveResult(ResolveResult targetResult, IMember member, IType returnTypeOverride = null)
+			: base(returnTypeOverride ?? (member.EntityType == EntityType.Constructor ? member.DeclaringType : member.ReturnType))
 		{
 			this.targetResult = targetResult;
 			this.member = member;
@@ -54,8 +54,8 @@ namespace ICSharpCode.NRefactory.Semantics
 			}
 		}
 		
-		public MemberResolveResult(ResolveResult targetResult, IMember member, bool isVirtualCall)
-			: base(member.EntityType == EntityType.Constructor ? member.DeclaringType : member.ReturnType)
+		public MemberResolveResult(ResolveResult targetResult, IMember member, bool isVirtualCall, IType returnTypeOverride = null)
+			: base(returnTypeOverride ?? (member.EntityType == EntityType.Constructor ? member.DeclaringType : member.ReturnType))
 		{
 			this.targetResult = targetResult;
 			this.member = member;


### PR DESCRIPTION
When invoking a method with dynamic arguments (and there is only one applicable method), convert the result of the call to 'dynamic' (http://blogs.msdn.com/b/ericlippert/archive/2012/10/22/a-method-group-of-one.aspx).

This fix might appear to decrease the IDE experience since it will cause code that has no chance of working to be reported witout errors, but it is in accordance with the C# spec.
