### PR TITLE
Added information about built-in conversions before and after a user-defined conversion operator is applied

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Resolver/CSharpResolver.cs
+++ b/ICSharpCode.NRefactory.CSharp/Resolver/CSharpResolver.cs
@@ -2311,7 +2311,7 @@ namespace ICSharpCode.NRefactory.CSharp.Resolver
 			if (!c.IsValid) {
 				var opTrue = input.Type.GetMethods(m => m.IsOperator && m.Name == "op_True").FirstOrDefault();
 				if (opTrue != null) {
-					c = Conversion.UserDefinedConversion(opTrue, isImplicit: true);
+					c = Conversion.UserDefinedConversion(opTrue, isImplicit: true, conversionBeforeUserDefinedOperator: Conversion.None, conversionAfterUserDefinedOperator: Conversion.None);
 				}
 			}
 			return Convert(input, boolean, c);
@@ -2331,7 +2331,7 @@ namespace ICSharpCode.NRefactory.CSharp.Resolver
 			if (!c.IsValid) {
 				var opFalse = input.Type.GetMethods(m => m.IsOperator && m.Name == "op_False").FirstOrDefault();
 				if (opFalse != null) {
-					c = Conversion.UserDefinedConversion(opFalse, isImplicit: true);
+					c = Conversion.UserDefinedConversion(opFalse, isImplicit: true, conversionBeforeUserDefinedOperator: Conversion.None, conversionAfterUserDefinedOperator: Conversion.None);
 					return Convert(input, boolean, c);
 				}
 			}

--- a/ICSharpCode.NRefactory.Tests/CSharp/Resolver/ConversionsTest.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/Resolver/ConversionsTest.cs
@@ -1251,5 +1251,44 @@ class Test {
 			Assert.IsTrue(c.IsUserDefined);
 			Assert.IsFalse(c.IsValid);
 		}
+
+		[Test]
+		public void UserDefinedImplicitConversion_ConversionBeforeUserDefinedOperatorIsCorrect() {
+			string program = @"using System;
+class Convertible {
+	public static implicit operator Convertible(long l) {return new Convertible(); }
+}
+class Test {
+	public void M() {
+		int i = 33;
+		Convertible a = $i$;
+	}
+}";
+			var c = GetConversion(program);
+			Assert.IsTrue(c.IsValid);
+			Assert.IsTrue(c.ConversionBeforeUserDefinedOperator.IsImplicit);
+			Assert.IsTrue(c.ConversionBeforeUserDefinedOperator.IsNumericConversion);
+			Assert.IsTrue(c.ConversionBeforeUserDefinedOperator.IsValid);
+			Assert.IsTrue(c.ConversionAfterUserDefinedOperator.IsIdentityConversion);
+		}
+
+		[Test]
+		public void UserDefinedImplicitConversion_ConversionAfterUserDefinedOperatorIsCorrect() {
+			string program = @"using System;
+class Convertible {
+	public static implicit operator int(Convertible i) {return 0; }
+}
+class Test {
+	public void M() {
+		long a = $new Convertible()$;
+	}
+}";
+			var c = GetConversion(program);
+			Assert.IsTrue(c.IsValid);
+			Assert.IsTrue(c.ConversionBeforeUserDefinedOperator.IsIdentityConversion);
+			Assert.IsTrue(c.ConversionAfterUserDefinedOperator.IsImplicit);
+			Assert.IsTrue(c.ConversionAfterUserDefinedOperator.IsNumericConversion);
+			Assert.IsTrue(c.ConversionAfterUserDefinedOperator.IsValid);
+		}
 	}
 }

--- a/ICSharpCode.NRefactory.Tests/CSharp/Resolver/ExplicitConversionsTest.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/Resolver/ExplicitConversionsTest.cs
@@ -870,5 +870,44 @@ class Test {
 			Assert.IsTrue(rr.Conversion.IsUserDefined);
 			Assert.AreEqual("ci", rr.Conversion.Method.Parameters[0].Name);
 		}
+
+		[Test]
+		public void UserDefinedExplicitConversion_ConversionBeforeUserDefinedOperatorIsCorrect() {
+			string program = @"using System;
+class Convertible {
+	public static implicit operator Convertible(int l) {return new Convertible(); }
+}
+class Test {
+	public void M() {
+		long i = 33;
+		Convertible a = $(Convertible)i$;
+	}
+}";
+			var rr = Resolve<ConversionResolveResult>(program);
+			Assert.IsTrue(rr.Conversion.IsValid);
+			Assert.IsTrue(rr.Conversion.ConversionBeforeUserDefinedOperator.IsValid);
+			Assert.IsTrue(rr.Conversion.ConversionBeforeUserDefinedOperator.IsExplicit);
+			Assert.IsTrue(rr.Conversion.ConversionBeforeUserDefinedOperator.IsNumericConversion);
+			Assert.IsTrue(rr.Conversion.ConversionAfterUserDefinedOperator.IsIdentityConversion);
+		}
+
+		[Test]
+		public void UserDefinedExplicitConversion_ConversionAfterUserDefinedOperatorIsCorrect() {
+			string program = @"using System;
+class Convertible {
+	public static implicit operator long(Convertible i) {return 0; }
+}
+class Test {
+	public void M() {
+		int a = $(int)new Convertible()$;
+	}
+}";
+			var rr = Resolve<ConversionResolveResult>(program);
+			Assert.IsTrue(rr.Conversion.IsValid);
+			Assert.IsTrue(rr.Conversion.ConversionBeforeUserDefinedOperator.IsIdentityConversion);
+			Assert.IsTrue(rr.Conversion.ConversionAfterUserDefinedOperator.IsValid);
+			Assert.IsTrue(rr.Conversion.ConversionAfterUserDefinedOperator.IsExplicit);
+			Assert.IsTrue(rr.Conversion.ConversionAfterUserDefinedOperator.IsNumericConversion);
+		}
 	}
 }

--- a/ICSharpCode.NRefactory/Semantics/Conversion.cs
+++ b/ICSharpCode.NRefactory/Semantics/Conversion.cs
@@ -75,26 +75,26 @@ namespace ICSharpCode.NRefactory.Semantics
 		public static readonly Conversion TryCast = new BuiltinConversion(false, 9);
 		
 		[Obsolete("Use UserDefinedConversion() instead")]
-		public static Conversion UserDefinedImplicitConversion(IMethod operatorMethod, bool isLifted)
+		public static Conversion UserDefinedImplicitConversion(IMethod operatorMethod, Conversion conversionBeforeUserDefinedOperator, Conversion conversionAfterUserDefinedOperator, bool isLifted)
 		{
 			if (operatorMethod == null)
 				throw new ArgumentNullException("operatorMethod");
-			return new UserDefinedConv(true, operatorMethod, isLifted, false);
+			return new UserDefinedConv(true, operatorMethod, conversionBeforeUserDefinedOperator, conversionAfterUserDefinedOperator, isLifted, false);
 		}
 		
 		[Obsolete("Use UserDefinedConversion() instead")]
-		public static Conversion UserDefinedExplicitConversion(IMethod operatorMethod, bool isLifted)
+		public static Conversion UserDefinedExplicitConversion(IMethod operatorMethod, Conversion conversionBeforeUserDefinedOperator, Conversion conversionAfterUserDefinedOperator, bool isLifted)
 		{
 			if (operatorMethod == null)
 				throw new ArgumentNullException("operatorMethod");
-			return new UserDefinedConv(false, operatorMethod, isLifted, false);
+			return new UserDefinedConv(false, operatorMethod, conversionBeforeUserDefinedOperator, conversionAfterUserDefinedOperator, isLifted, false);
 		}
 		
-		public static Conversion UserDefinedConversion(IMethod operatorMethod, bool isImplicit, bool isLifted = false, bool isAmbiguous = false)
+		public static Conversion UserDefinedConversion(IMethod operatorMethod, bool isImplicit, Conversion conversionBeforeUserDefinedOperator, Conversion conversionAfterUserDefinedOperator, bool isLifted = false, bool isAmbiguous = false)
 		{
 			if (operatorMethod == null)
 				throw new ArgumentNullException("operatorMethod");
-			return new UserDefinedConv(isImplicit, operatorMethod, isLifted, isAmbiguous);
+			return new UserDefinedConv(isImplicit, operatorMethod, conversionBeforeUserDefinedOperator, conversionAfterUserDefinedOperator, isLifted, isAmbiguous);
 		}
 		
 		public static Conversion MethodGroupConversion(IMethod chosenMethod, bool isVirtualMethodLookup)
@@ -275,13 +275,17 @@ namespace ICSharpCode.NRefactory.Semantics
 		{
 			readonly IMethod method;
 			readonly bool isLifted;
+			readonly Conversion conversionBeforeUserDefinedOperator;
+			readonly Conversion conversionAfterUserDefinedOperator;
 			readonly bool isImplicit;
 			readonly bool isValid;
 			
-			public UserDefinedConv(bool isImplicit, IMethod method, bool isLifted, bool isAmbiguous)
+			public UserDefinedConv(bool isImplicit, IMethod method, Conversion conversionBeforeUserDefinedOperator, Conversion conversionAfterUserDefinedOperator, bool isLifted, bool isAmbiguous)
 			{
 				this.method = method;
 				this.isLifted = isLifted;
+				this.conversionBeforeUserDefinedOperator = conversionBeforeUserDefinedOperator;
+				this.conversionAfterUserDefinedOperator = conversionAfterUserDefinedOperator;
 				this.isImplicit = isImplicit;
 				this.isValid = !isAmbiguous;
 			}
@@ -306,6 +310,14 @@ namespace ICSharpCode.NRefactory.Semantics
 				get { return true; }
 			}
 			
+			public override Conversion ConversionBeforeUserDefinedOperator {
+				get { return conversionBeforeUserDefinedOperator; }
+			}
+		
+			public override Conversion ConversionAfterUserDefinedOperator {
+				get { return conversionAfterUserDefinedOperator; }
+			}
+
 			public override IMethod Method {
 				get { return method; }
 			}
@@ -456,7 +468,21 @@ namespace ICSharpCode.NRefactory.Semantics
 		public virtual bool IsUserDefined {
 			get { return false; }
 		}
+
+		/// <summary>
+		/// The conversion that is applied to the input before the user-defined conversion operator is invoked.
+		/// </summary>
+		public virtual Conversion ConversionBeforeUserDefinedOperator {
+			get { return null; }
+		}
 		
+		/// <summary>
+		/// The conversion that is applied to the result of the user-defined conversion operator.
+		/// </summary>
+		public virtual Conversion ConversionAfterUserDefinedOperator {
+			get { return null; }
+		}
+
 		/// <summary>
 		/// Gets whether this conversion is a boxing conversion.
 		/// </summary>


### PR DESCRIPTION
Made this information available in two members on the `Conversion` class.
