### PR TITLE
Add a ConversionResolveResult to lambda body expressions, if required

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Resolver/ResolveVisitor.cs
+++ b/ICSharpCode.NRefactory.CSharp/Resolver/ResolveVisitor.cs
@@ -2032,7 +2032,7 @@ namespace ICSharpCode.NRefactory.CSharp.Resolver
 						Analyze();
 						if (returnValues.Count == 1) {
 							bodyRR = returnValues[0];
-							if (!actualReturnType.Equals(SpecialType.UnknownType)) {
+							if (!actualReturnType.IsKnownType(KnownTypeCode.Void)) {
 								var conv = storedContext.conversions.ImplicitConversion(bodyRR, actualReturnType);
 								if (!conv.IsIdentityConversion)
 									bodyRR = new ConversionResolveResult(actualReturnType, bodyRR, conv, storedContext.CheckForOverflow);

--- a/ICSharpCode.NRefactory.Tests/CSharp/Resolver/LambdaTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/Resolver/LambdaTests.cs
@@ -700,7 +700,7 @@ class Test {
 			string program = @"using System;
 class Test {
 	public object M() {
-		System.Action<int, string> f = $(int i) => i++$;
+		System.Action<int> f = $(int i) => i++$;
 	}
 }";
 			var rr = Resolve<LambdaResolveResult>(program);


### PR DESCRIPTION
Insert a conversion into the body of lambda expressions, if required
