### PR TITLE
Ensure the list returned by IMember.ImplementedInterfaceMembers is read-only

### DIFF
--- a/ICSharpCode.NRefactory/TypeSystem/Implementation/AbstractResolvedMember.cs
+++ b/ICSharpCode.NRefactory/TypeSystem/Implementation/AbstractResolvedMember.cs
@@ -75,18 +75,16 @@ namespace ICSharpCode.NRefactory.TypeSystem.Implementation
 					if (member != null)
 						result.Add(member);
 				}
-				return result.ToArray();
+				return result.AsReadOnly();
 			} else if (unresolved.IsStatic || !unresolved.IsPublic || DeclaringTypeDefinition == null || DeclaringTypeDefinition.Kind == TypeKind.Interface) {
 				return EmptyList<IMember>.Instance;
 			} else {
 				// TODO: implement interface member mappings correctly
 				var result = InheritanceHelper.GetBaseMembers(this, true)
 					.Where(m => m.DeclaringTypeDefinition != null && m.DeclaringTypeDefinition.Kind == TypeKind.Interface)
-					.ToArray();
+					.Where(item => !DeclaringTypeDefinition.Members.Any(m => m.IsExplicitInterfaceImplementation && m.ImplementedInterfaceMembers.Contains(item)));
 
-				result = result.Where(item => !DeclaringTypeDefinition.Members.Any(m => m.IsExplicitInterfaceImplementation && m.ImplementedInterfaceMembers.Contains(item))).ToArray();
-
-				return result;
+				return result.ToList().AsReadOnly();
 			}
 		}
 		

--- a/ICSharpCode.NRefactory/TypeSystem/Implementation/SpecializedMember.cs
+++ b/ICSharpCode.NRefactory/TypeSystem/Implementation/SpecializedMember.cs
@@ -208,7 +208,7 @@ namespace ICSharpCode.NRefactory.TypeSystem.Implementation
 			for (int i = 0; i < result.Length; i++) {
 				result[i] = definitionImplementations[i].Specialize(substitution);
 			}
-			return result;
+			return Array.AsReadOnly(result);
 		}
 		
 		public bool IsExplicitInterfaceImplementation {


### PR DESCRIPTION
Just something I stumbled upon: The entire type system is supposed to be immutable, but `IMember.ImplementedInterfaceMembers` returns a mutable list.
