### PR TITLE
[CodeIssue] Redundant Null Reference check

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/ICSharpCode.NRefactory.CSharp.csproj
+++ b/ICSharpCode.NRefactory.CSharp/ICSharpCode.NRefactory.CSharp.csproj
@@ -527,6 +527,7 @@
     <Compile Include="Formatter\FormattingVisitor_Statements.cs" />
     <Compile Include="Formatter\FormattingVisitor_Expressions.cs" />
     <Compile Include="Formatter\FormattingChanges.cs" />
+    <Compile Include="Refactoring\CodeIssues\RedundantNullCheckIssue.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ICSharpCode.NRefactory\ICSharpCode.NRefactory.csproj">

--- a/ICSharpCode.NRefactory.CSharp/Refactoring/CodeIssues/RedundantNullCheckIssue.cs
+++ b/ICSharpCode.NRefactory.CSharp/Refactoring/CodeIssues/RedundantNullCheckIssue.cs
@@ -1,0 +1,121 @@
+//
+// RedundantToStringIssue.cs
+//
+// Author:
+//       Ji Kun <jikun.nus@gmail.com>
+//
+// Copyright (c) 2013 Ji Kun
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using System.Collections.Generic;
+using ICSharpCode.NRefactory.PatternMatching;
+using ICSharpCode.NRefactory.TypeSystem;
+using ICSharpCode.NRefactory.CSharp.Resolver;
+using ICSharpCode.NRefactory.Semantics;
+using System.Linq;
+using ICSharpCode.NRefactory.TypeSystem.Implementation;
+
+namespace ICSharpCode.NRefactory.CSharp.Refactoring
+{
+	[IssueDescription("Redundant null check",
+					  Description = "When 'is' keyword is used, which implicitly check null.",
+					  Category = IssueCategories.Redundancies,
+					  Severity = Severity.Suggestion,
+					  IssueMarker = IssueMarker.GrayOut)]
+	public class RedundantNullCheckIssue : ICodeIssueProvider
+	{
+	    private static readonly Pattern pattern1
+            = new Choice
+	    {
+	        //  x is Record && x!= null     
+	        new BinaryOperatorExpression(
+	            new IsExpression
+	                {
+	                    Expression = new AnyNode("a"),
+	                    Type = new AnyNode("t")
+	                }, BinaryOperatorType.ConditionalAnd,
+	            PatternHelper.CommutativeOperator(new Backreference("a"),
+	                                                BinaryOperatorType.
+	                                                    InEquality,
+	                                                new NullReferenceExpression
+	                                                    ())
+	            )
+	    };
+
+        private static readonly Pattern pattern2
+           = new Choice
+	    {
+			//  x != null && x is Record
+            new BinaryOperatorExpression (
+                PatternHelper.CommutativeOperator (new AnyNode("a"), 
+                                                        BinaryOperatorType.InEquality, 
+                                                    new NullReferenceExpression())			
+				, BinaryOperatorType.ConditionalAnd,
+		        new IsExpression {
+					Expression = new Backreference("a"),
+					Type = new AnyNode("t")
+				}
+			)	
+		};
+
+		public IEnumerable<CodeIssue> GetIssues(BaseRefactoringContext context)
+		{
+			return new GatherVisitor(context).GetIssues();
+		}
+
+        class GatherVisitor : GatherVisitorBase<RedundantNullCheckIssue>
+		{
+            public GatherVisitor(BaseRefactoringContext ctx)
+                : base(ctx)
+            {
+            }
+
+            public override void VisitBinaryOperatorExpression(BinaryOperatorExpression binaryOperatorExpression)
+            {
+                base.VisitBinaryOperatorExpression(binaryOperatorExpression);
+                Match m1 = pattern1.Match(binaryOperatorExpression);
+                if (m1.Success)
+                {
+                    AddIssue(binaryOperatorExpression, ctx.TranslateString("Remove redundant IsNULL check"), script =>
+                    {
+                        Expression expr = binaryOperatorExpression.Left;
+                        script.Replace(binaryOperatorExpression, expr);
+                    });
+                    return;
+                }
+
+                Match m2 = pattern2.Match(binaryOperatorExpression);
+                if (m2.Success)
+                {
+                    AddIssue(binaryOperatorExpression, ctx.TranslateString("Remove redundant IsNULL check"), script =>
+                    {
+                        Expression expr = binaryOperatorExpression.Right;
+                        script.Replace(binaryOperatorExpression, expr);
+                    });
+                    return;
+                }
+
+            }
+
+		}
+	}
+}
+

--- a/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/RedundantNullCheckTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/RedundantNullCheckTests.cs
@@ -1,0 +1,70 @@
+// 
+// RedundantPrivateInspectorTests.cs
+//  
+// Author:
+//       Ji Kun <jikun.nus@gmail.com>
+// 
+// Copyright (c) 2013 Ji Kun
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using NUnit.Framework;
+using ICSharpCode.NRefactory.CSharp.Refactoring;
+using ICSharpCode.NRefactory.CSharp.CodeActions;
+
+namespace ICSharpCode.NRefactory.CSharp.CodeIssues
+{
+	[TestFixture]
+	public class RedundantNullCheckTests : InspectionActionTestBase
+	{
+		[Test]
+		public void TestInspectorCase1 ()
+		{
+			var input = @"using System;class Test {public void test(){int a = 0;if(a is int && a != null){a = 1;}}}";
+
+			TestRefactoringContext context;
+			var issues = GetIssues (new RedundantNullCheckIssue(), input, out context);
+			Assert.AreEqual (1, issues.Count);
+
+			
+			CheckFix (context, issues, @"using System;class Test {public void test(){int a = 0;
+		if (a is int) {
+			a = 1;
+		}}}");
+		}
+
+        [Test]
+        public void TestInspectorCase2()
+        {
+			var input = @"using System;class Test {public void test(){int a = 0;while(a != null && a is int){a = 1;}}}";
+
+
+            TestRefactoringContext context;
+			var issues = GetIssues(new RedundantNullCheckIssue(), input, out context);
+            Assert.AreEqual (1, issues.Count);
+
+
+			CheckFix(context, issues, @"using System;class Test {public void test(){int a = 0;
+		while (a is int) {
+			a = 1;
+		}}}");
+        }
+	}
+}

--- a/ICSharpCode.NRefactory.Tests/ICSharpCode.NRefactory.Tests.csproj
+++ b/ICSharpCode.NRefactory.Tests/ICSharpCode.NRefactory.Tests.csproj
@@ -402,6 +402,7 @@
     <Compile Include="CSharp\CodeIssues\NoDefaultConstructorIssueTests.cs" />
     <Compile Include="CSharp\CodeActions\InvertIfAndSimplifyTests.cs" />
     <Compile Include="FormattingTests\TestExpressionFormatting.cs" />
+    <Compile Include="CSharp\CodeIssues\RedundantNullCheckTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\cecil\Mono.Cecil.csproj">


### PR DESCRIPTION
No need to check null reference where is keyword exits.
//if (a is int && a != null){}
