### PR TITLE
Basic fix for bug #10730

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/ICSharpCode.NRefactory.CSharp.csproj
+++ b/ICSharpCode.NRefactory.CSharp/ICSharpCode.NRefactory.CSharp.csproj
@@ -278,6 +278,7 @@
     <Compile Include="Refactoring\CodeActions\ConvertLambdaBodyExpressionToStatementAction.cs" />
     <Compile Include="Refactoring\CodeActions\ConvertLambdaBodyStatementToExpressionAction.cs" />
     <Compile Include="Refactoring\CodeActions\ConvertSwitchToIfAction.cs" />
+    <Compile Include="Refactoring\CodeActions\ConvertToStaticMethodAction.cs" />
     <Compile Include="Refactoring\CodeActions\CreateCustomEventImplementationAction.cs" />
     <Compile Include="Refactoring\CodeActions\CreateOverloadWithoutParameterAction.cs" />
     <Compile Include="Refactoring\CodeActions\JoinDeclarationAndAssignmentAction.cs" />

--- a/ICSharpCode.NRefactory.CSharp/Refactoring/CodeActions/ConvertToStaticMethodAction.cs
+++ b/ICSharpCode.NRefactory.CSharp/Refactoring/CodeActions/ConvertToStaticMethodAction.cs
@@ -1,0 +1,67 @@
+﻿
+// ConvertToStaticMethodAction.cs
+//
+// Author:
+//      Ciprian Khlud <ciprian.mustiata@yahoo.com>
+//
+// Copyright (c) 2013 Ciprian Khlud <ciprian.mustiata@yahoo.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System.Collections.Generic;
+using ICSharpCode.NRefactory.CSharp.Refactoring.ExtractMethod;
+
+namespace ICSharpCode.NRefactory.CSharp.Refactoring
+{
+	[ContextAction("Make this method static", Description = "This method doesn't use any non static members so it can be made static")]
+	public class ConvertToStaticMethodAction : ICodeActionProvider
+	{
+	    public IEnumerable<CodeAction> GetActions(RefactoringContext context)
+		{
+			// TODO: Invert if without else
+			// ex. if (cond) DoSomething () == if (!cond) return; DoSomething ()
+			// beware of loop contexts return should be continue then.
+			var methodDeclaration = GetMethodDeclaration(context);
+			if (methodDeclaration == null)
+				yield break;
+            yield return new CodeAction(context.TranslateString("Make it static"), script =>
+            {
+                var clonedDeclaration = (MethodDeclaration)methodDeclaration.Clone();
+                clonedDeclaration.Modifiers |= Modifiers.Static;
+                script.Replace(methodDeclaration, clonedDeclaration);
+
+			}, methodDeclaration);
+		}
+
+	    static MethodDeclaration GetMethodDeclaration(RefactoringContext context)
+		{
+            var result = context.GetNode <MethodDeclaration>();
+			if (result == null)
+                return null;
+            //unsafe transformation for now. For all other public instances the code should 
+            //replace the variable.Call(...) to ClassName.Call()
+            const Modifiers ignoredModifiers = Modifiers.Public | Modifiers.Protected | Modifiers.Static;
+            if ((result.Modifiers & ignoredModifiers) != 0)
+                return null;
+
+            var usesNonStatic = StaticVisitor.UsesNotStaticMember(context, result);
+            if (usesNonStatic) return null;
+            return result;
+        }
+	}
+}

--- a/ICSharpCode.NRefactory.Tests/CSharp/CodeActions/ConvertToStaticMethodActionTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/CodeActions/ConvertToStaticMethodActionTests.cs
@@ -1,0 +1,79 @@
+//
+// ConvertToStaticMethodActionTests.cs
+//
+// Author:
+//      Ciprian Khlud <ciprian.mustiata@yahoo.com>
+//
+// Copyright (c) 2013 Ciprian Khlud <ciprian.mustiata@yahoo.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using ICSharpCode.NRefactory.CSharp.Refactoring;
+using NUnit.Framework;
+
+namespace ICSharpCode.NRefactory.CSharp.CodeActions {
+    [TestFixture]
+    public class ConvertToStaticMethodActionTests : ContextActionTestBase
+    {
+        [Test]
+        public void Test()
+        {
+            Test<ConvertToStaticMethodAction>(
+                @"class TestClass
+{
+	void $Test ()
+	{
+		int a = 2;
+	}
+}",
+                @"class TestClass
+{
+	static void Test ()
+	{
+		int a = 2;
+	}
+}"
+                );
+        }
+        [Test]
+        public void TestWithPublicFunction() {
+            
+            var input = @"class TestClass
+{
+	public void $Test ()
+	{
+		int a = 2;
+	}
+}";
+            TestWrongContext<ConvertToStaticMethodAction>(input);
+        }
+        [Test]
+        public void TestWithStaticFunction()
+        {
+
+            var input = @"class TestClass
+{
+	static void $Test ()
+	{
+		int a = 2;
+	}
+}";
+            TestWrongContext<ConvertToStaticMethodAction>(input);
+        }
+    }
+}

--- a/ICSharpCode.NRefactory.Tests/ICSharpCode.NRefactory.Tests.csproj
+++ b/ICSharpCode.NRefactory.Tests/ICSharpCode.NRefactory.Tests.csproj
@@ -109,6 +109,7 @@
     <Compile Include="CSharp\CodeActions\ConvertLambdaBodyExpressionToStatementTests.cs" />
     <Compile Include="CSharp\CodeActions\ConvertLambdaBodyStatementToExpressionTests.cs" />
     <Compile Include="CSharp\CodeActions\ConvertSwitchToIfTests.cs" />
+    <Compile Include="CSharp\CodeActions\ConvertToStaticMethodActionTests.cs" />
     <Compile Include="CSharp\CodeActions\CreateCustomEventImplementationTests.cs" />
     <Compile Include="CSharp\CodeActions\CreateOverloadWithoutParameterTests.cs" />
     <Compile Include="CSharp\CodeActions\ExtractAnonymousMethodTests.cs" />


### PR DESCRIPTION
A better than nothing implementation of Bug #10730.
https://bugzilla.xamarin.com/show_bug.cgi?id=10730
When multi-file tracking of methods is implemented, the change should change the usages of variables.Call(...) to ClassName.Call(...)
