### PR TITLE
Added property Conversion.IsExtensionMethodGroupConversion

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Resolver/CSharpConversions.cs
+++ b/ICSharpCode.NRefactory.CSharp/Resolver/CSharpConversions.cs
@@ -1064,9 +1064,9 @@ namespace ICSharpCode.NRefactory.CSharp.Resolver
 				bool isVirtual = method.IsOverridable && !(thisRR != null && thisRR.CausesNonVirtualInvocation);
 				bool isValid = !or.IsAmbiguous && IsDelegateCompatible(method, invoke, or.IsExtensionMethodInvocation);
 				if (isValid)
-					return Conversion.MethodGroupConversion(method, isVirtual);
+					return Conversion.MethodGroupConversion(method, isVirtual, or.IsExtensionMethodInvocation);
 				else
-					return Conversion.InvalidMethodGroupConversion(method, isVirtual);
+					return Conversion.InvalidMethodGroupConversion(method, isVirtual, or.IsExtensionMethodInvocation);
 			} else {
 				return Conversion.None;
 			}

--- a/ICSharpCode.NRefactory.Tests/CSharp/Resolver/ConversionsTest.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/Resolver/ConversionsTest.cs
@@ -833,6 +833,45 @@ class Test {
 		}
 
 		[Test]
+		public void MethodGroupConversion_ExtensionMethod()
+		{
+			string program = @"using System;
+static class Ext {
+	public void M(this string s, int x) {}
+}
+class Test {
+	delegate void D(int a);
+	void F() {
+		string s = """";
+		D d = $s.M$;
+	}
+}";
+			var c = GetConversion(program);
+			Assert.IsTrue(c.IsValid);
+			Assert.IsTrue(c.IsMethodGroupConversion);
+			Assert.IsTrue(c.IsExtensionMethodGroupConversion);
+		}
+
+		[Test]
+		public void MethodGroupConversion_ExtensionMethodUsedAsStaticMethod()
+		{
+			string program = @"using System;
+static class Ext {
+	public void M(this string s, int x) {}
+}
+class Test {
+	delegate void D(string s, int a);
+	void F() {
+		D d = $Ext.M$;
+	}
+}";
+			var c = GetConversion(program);
+			Assert.IsTrue(c.IsValid);
+			Assert.IsTrue(c.IsMethodGroupConversion);
+			Assert.IsFalse(c.IsExtensionMethodGroupConversion);
+		}
+
+		[Test]
 		public void UserDefined_IntLiteral_ViaUInt_ToCustomStruct()
 		{
 			string program = @"using System;

--- a/ICSharpCode.NRefactory/Semantics/Conversion.cs
+++ b/ICSharpCode.NRefactory/Semantics/Conversion.cs
@@ -97,18 +97,18 @@ namespace ICSharpCode.NRefactory.Semantics
 			return new UserDefinedConv(isImplicit, operatorMethod, conversionBeforeUserDefinedOperator, conversionAfterUserDefinedOperator, isLifted, isAmbiguous);
 		}
 		
-		public static Conversion MethodGroupConversion(IMethod chosenMethod, bool isVirtualMethodLookup)
+		public static Conversion MethodGroupConversion(IMethod chosenMethod, bool isVirtualMethodLookup, bool isExtensionMethodGroupConversion)
 		{
 			if (chosenMethod == null)
 				throw new ArgumentNullException("chosenMethod");
-			return new MethodGroupConv(chosenMethod, isVirtualMethodLookup, isValid: true);
+			return new MethodGroupConv(chosenMethod, isVirtualMethodLookup, isExtensionMethodGroupConversion, isValid: true);
 		}
 		
-		public static Conversion InvalidMethodGroupConversion(IMethod chosenMethod, bool isVirtualMethodLookup)
+		public static Conversion InvalidMethodGroupConversion(IMethod chosenMethod, bool isVirtualMethodLookup, bool isExtensionMethodGroupConversion)
 		{
 			if (chosenMethod == null)
 				throw new ArgumentNullException("chosenMethod");
-			return new MethodGroupConv(chosenMethod, isVirtualMethodLookup, isValid: false);
+			return new MethodGroupConv(chosenMethod, isVirtualMethodLookup, isExtensionMethodGroupConversion, isValid: false);
 		}
 		#endregion
 		
@@ -346,12 +346,14 @@ namespace ICSharpCode.NRefactory.Semantics
 		{
 			readonly IMethod method;
 			readonly bool isVirtualMethodLookup;
+			readonly bool isExtensionMethodGroupConversion;
 			readonly bool isValid;
 			
-			public MethodGroupConv(IMethod method, bool isVirtualMethodLookup, bool isValid)
+			public MethodGroupConv(IMethod method, bool isVirtualMethodLookup, bool isExtensionMethodGroupConversion, bool isValid)
 			{
 				this.method = method;
 				this.isVirtualMethodLookup = isVirtualMethodLookup;
+				this.isExtensionMethodGroupConversion = isExtensionMethodGroupConversion;
 				this.isValid = isValid;
 			}
 			
@@ -371,6 +373,10 @@ namespace ICSharpCode.NRefactory.Semantics
 				get { return isVirtualMethodLookup; }
 			}
 			
+			public override bool IsExtensionMethodGroupConversion {
+				get { return isExtensionMethodGroupConversion; }
+			}
+
 			public override IMethod Method {
 				get { return method; }
 			}
@@ -518,6 +524,13 @@ namespace ICSharpCode.NRefactory.Semantics
 			get { return false; }
 		}
 		
+		/// <summary>
+		/// For method-group conversions, gets whether the conversion is a method group conversion of an extension method performed on an instance (eg. Func&lt;int&gt; f = myEnumerable.Single).
+		/// </summary>
+		public virtual bool IsExtensionMethodGroupConversion {
+			get { return false; }
+		}
+
 		/// <summary>
 		/// Gets whether this conversion is an anonymous function conversion.
 		/// </summary>


### PR DESCRIPTION
to determine whether a method group conversion is being performed on an extension method using extension method invocation syntax (eg. `Func<int> f = myEnumerable.Single`).
