### PR TITLE
Fixed issue with ImplementedInterfaceMembers for accessors

### DIFF
--- a/ICSharpCode.NRefactory.Tests/TypeSystem/TypeSystemTests.TestCase.cs
+++ b/ICSharpCode.NRefactory.Tests/TypeSystem/TypeSystemTests.TestCase.cs
@@ -374,4 +374,23 @@ namespace ICSharpCode.NRefactory.TypeSystem.TestCase
 		public const int SObl = sizeof(bool);
 		public const int SOe  = sizeof(MyEnum);
 	}
+
+	public interface IExplicitImplementationTests {
+		void M(int a);
+		int P { get; set; }
+		event Action E;
+		int this[int x] { get; set; }
+	}
+
+	public class ExplicitImplementationTests : IExplicitImplementationTests {
+		public void M(int a) {}
+		public int P { get; set; }
+		public event Action E;
+		public int this[int x] { get { return 0; } set {} }
+
+		void IExplicitImplementationTests.M(int a) {}
+		int IExplicitImplementationTests.P { get; set; }
+		event Action IExplicitImplementationTests.E { add {} remove {} }
+		int IExplicitImplementationTests.this[int x] { get { return 0; } set {} }
+	}
 }

--- a/ICSharpCode.NRefactory.Tests/TypeSystem/TypeSystemTests.cs
+++ b/ICSharpCode.NRefactory.Tests/TypeSystem/TypeSystemTests.cs
@@ -1289,5 +1289,43 @@ namespace ICSharpCode.NRefactory.TypeSystem
 			AssertConstantField<int>(type, "SObl", sizeof(bool));
 			AssertConstantField<int>(type, "SOe", sizeof(MyEnum));
 		}
+
+		[Test]
+		public void ExplicitImplementation() {
+			var type = GetTypeDefinition(typeof(ExplicitImplementationTests));
+			var itype = GetTypeDefinition(typeof(IExplicitImplementationTests));
+
+			var methods = type.GetMethods(m => m.Name == "M").ToList();
+			var imethod = itype.GetMethods(m => m.Name == "M").Single();
+			Assert.That(methods.Select(m => m.ImplementedInterfaceMembers.Count).ToList(), Is.EquivalentTo(new[] { 0, 1 }));
+			Assert.AreEqual(methods.SelectMany(m => m.ImplementedInterfaceMembers).Single(), imethod);
+
+			var properties = type.GetProperties(p => p.Name == "P").ToList();
+			var iproperty  = itype.GetProperties(m => m.Name == "P").Single();
+			Assert.That(properties.Select(p => p.ImplementedInterfaceMembers.Count).ToList(), Is.EquivalentTo(new[] { 0, 1 }));
+			Assert.AreEqual(properties.SelectMany(p => p.ImplementedInterfaceMembers).Single(), iproperty);
+			Assert.That(properties.Select(p => p.Getter.ImplementedInterfaceMembers.Count).ToList(), Is.EquivalentTo(new[] { 0, 1 }));
+			Assert.AreEqual(properties.SelectMany(p => p.Getter.ImplementedInterfaceMembers).Single(), iproperty.Getter);
+			Assert.That(properties.Select(p => p.Setter.ImplementedInterfaceMembers.Count).ToList(), Is.EquivalentTo(new[] { 0, 1 }));
+			Assert.AreEqual(properties.SelectMany(p => p.Setter.ImplementedInterfaceMembers).Single(), iproperty.Setter);
+
+			var indexers = type.GetProperties(p => p.Name == "Item").ToList();
+			var iindexer = itype.GetProperties(m => m.Name == "Item").Single();
+			Assert.That(indexers.Select(p => p.ImplementedInterfaceMembers.Count).ToList(), Is.EquivalentTo(new[] { 0, 1 }));
+			Assert.AreEqual(indexers.SelectMany(p => p.ImplementedInterfaceMembers).Single(), iindexer);
+			Assert.That(indexers.Select(p => p.Getter.ImplementedInterfaceMembers.Count).ToList(), Is.EquivalentTo(new[] { 0, 1 }));
+			Assert.AreEqual(indexers.SelectMany(p => p.Getter.ImplementedInterfaceMembers).Single(), iindexer.Getter);
+			Assert.That(indexers.Select(p => p.Setter.ImplementedInterfaceMembers.Count).ToList(), Is.EquivalentTo(new[] { 0, 1 }));
+			Assert.AreEqual(indexers.SelectMany(p => p.Setter.ImplementedInterfaceMembers).Single(), iindexer.Setter);
+
+			var events = type.GetEvents(e => e.Name == "E").ToList();
+			var ievent = itype.GetEvents(m => m.Name == "E").Single();
+			Assert.That(events.Select(e => e.ImplementedInterfaceMembers.Count).ToList(), Is.EquivalentTo(new[] { 0, 1 }));
+			Assert.AreEqual(events.SelectMany(e => e.ImplementedInterfaceMembers).Single(), ievent);
+			Assert.That(events.Select(e => e.AddAccessor.ImplementedInterfaceMembers.Count).ToList(), Is.EquivalentTo(new[] { 0, 1 }));
+			Assert.AreEqual(events.SelectMany(e => e.AddAccessor.ImplementedInterfaceMembers).Single(), ievent.AddAccessor);
+			Assert.That(events.Select(e => e.RemoveAccessor.ImplementedInterfaceMembers.Count).ToList(), Is.EquivalentTo(new[] { 0, 1 }));
+			Assert.AreEqual(events.SelectMany(e => e.RemoveAccessor.ImplementedInterfaceMembers).Single(), ievent.RemoveAccessor);
+		}
 	}
 }

--- a/ICSharpCode.NRefactory/TypeSystem/Implementation/AbstractResolvedMember.cs
+++ b/ICSharpCode.NRefactory/TypeSystem/Implementation/AbstractResolvedMember.cs
@@ -84,7 +84,8 @@ namespace ICSharpCode.NRefactory.TypeSystem.Implementation
 					.Where(m => m.DeclaringTypeDefinition != null && m.DeclaringTypeDefinition.Kind == TypeKind.Interface)
 					.ToArray();
 
-				result = result.Where(item => !DeclaringTypeDefinition.Members.Any(m => m.IsExplicitInterfaceImplementation && m.ImplementedInterfaceMembers.Contains(item))).ToArray();
+				var otherMembers = EntityType == EntityType.Accessor ? DeclaringType.GetAccessors() : DeclaringType.GetMembers();
+				result = result.Where(item => !otherMembers.Any(m => m.IsExplicitInterfaceImplementation && m.ImplementedInterfaceMembers.Contains(item))).ToArray();
 
 				return result;
 			}


### PR DESCRIPTION
This fixes an issue causing the type system to believe that accessors implement interface members even though there is an explicit implementation of the accessor owner.

@dgrunwald: This solution has "hack factor" 95%. Is there any chance you can take a look at #63? I think it's way more likely that you will create a valid implementation than it is that I will.
