### PR TITLE
Prevent UseExplicitTypeAction for anonymous types.

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Refactoring/CodeActions/UseExplicitTypeAction.cs
+++ b/ICSharpCode.NRefactory.CSharp/Refactoring/CodeActions/UseExplicitTypeAction.cs
@@ -52,7 +52,7 @@ namespace ICSharpCode.NRefactory.CSharp.Refactoring
 				node = foreachStatement;
 			}
 			
-			if (!(!type.Equals(SpecialType.NullType) && !type.Equals(SpecialType.UnknownType))) {
+			if (!(!type.Equals(SpecialType.NullType) && !type.Equals(SpecialType.UnknownType) && type.Kind != TypeKind.Anonymous)) {
 				yield break;
 			}
 			yield return new CodeAction (context.TranslateString("Use explicit type"), script => {


### PR DESCRIPTION
Currently, UseExplicitTypeAction replaces "var x = new { A = 1 };" by "Anonymous Type x = new { A = 1 };".
This behavior is incorrect. There is no adequate way to make a type explicit when it comes to anonymous types, so this commit just disables it completely for anonymous types.
