### PR TITLE
ConvertLambdaToAnonymousDelegates now works correctly for lambdas with a...

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Refactoring/CodeActions/ConvertLambdaToAnonymousDelegateAction.cs
+++ b/ICSharpCode.NRefactory.CSharp/Refactoring/CodeActions/ConvertLambdaToAnonymousDelegateAction.cs
@@ -51,7 +51,7 @@ namespace ICSharpCode.NRefactory.CSharp.Refactoring
 				} else {
 					newBody = new BlockStatement {
 						Statements = {
-							new ExpressionStatement((Expression)node.Body.Clone())
+							new ReturnStatement((Expression)node.Body.Clone())
 						}
 					};
 				}


### PR DESCRIPTION
Currently, using Convert Lambda To Anonymous Delegate does not work for expressions such as "foo => foo".
Instead of generating "delegate (int foo) { return foo; }", the action generates "delegate (int foo) { foo; }" which is incorrect.
This commit fixes that.
