### PR TITLE
Fix to ConvertLambdaToAnonymousDelegate

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Refactoring/CodeActions/ConvertLambdaToAnonymousDelegateAction.cs
+++ b/ICSharpCode.NRefactory.CSharp/Refactoring/CodeActions/ConvertLambdaToAnonymousDelegateAction.cs
@@ -49,9 +49,19 @@ namespace ICSharpCode.NRefactory.CSharp.Refactoring
 				if (node.Body is BlockStatement) {
 					newBody = (BlockStatement)node.Body.Clone();
 				} else {
+					var expression = (Expression)node.Body.Clone();
+
+					Statement statement;
+					if (RequireReturnStatement(context, node)) {
+						statement = new ReturnStatement(expression);
+					}
+					else {
+						statement = new ExpressionStatement(expression);
+					}
+
 					newBody = new BlockStatement {
 						Statements = {
-							new ReturnStatement((Expression)node.Body.Clone())
+							statement
 						}
 					};
 				}
@@ -77,6 +87,12 @@ namespace ICSharpCode.NRefactory.CSharp.Refactoring
 				result.Add (new ParameterDeclaration(type, name, modifier));
 			}
 			return result;
+		}
+
+		static bool RequireReturnStatement (RefactoringContext context, LambdaExpression lambda)
+		{
+			var type = LambdaHelper.GetLambdaReturnType (context, lambda);
+			return type != null && type.ReflectionName != "System.Void";
 		}
 	}
 }


### PR DESCRIPTION
My previous change to this file failed to consider () => VoidMethod and incorrectly generated () => { return VoidMethod(); }

I believe this new commit should fix that. I have essentially copied RequireReturnStatement from ConvertLambdaBodyExpressionToStatementAction and added a few extra local variables for clarity.
