### PR TITLE
Fixed LambdaHelper for extension methods

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Refactoring/LambdaHelper.cs
+++ b/ICSharpCode.NRefactory.CSharp/Refactoring/LambdaHelper.cs
@@ -43,6 +43,9 @@ namespace ICSharpCode.NRefactory.CSharp.Refactoring
 				var invocation = (InvocationExpression)parent;
 				var argIndex = invocation.Arguments.TakeWhile (arg => !arg.Contains (lambda.StartLocation)).Count ();
 				var resolveResult = (CSharpInvocationResolveResult)context.Resolve (invocation);
+				if (resolveResult.IsExtensionMethodInvocation) {
+					++argIndex;
+				}
 				delegateTypeDef = resolveResult.Arguments [argIndex].Type.GetDefinition ();
 			} else {
 				delegateTypeDef = context.Resolve (parent).Type.GetDefinition ();

--- a/ICSharpCode.NRefactory.Tests/CSharp/Refactoring/LambdaHelperTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/Refactoring/LambdaHelperTests.cs
@@ -1,0 +1,64 @@
+//
+// LambdaHelperTests.cs
+//
+// Author:
+//       Luís Reis <luiscubal@gmail.com>
+//
+// Copyright (c) 2013 Luís Reis
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using NUnit.Framework;
+using System;
+using System.Linq;
+using ICSharpCode.NRefactory.CSharp.Refactoring;
+using ICSharpCode.NRefactory.CSharp.CodeActions;
+using ICSharpCode.NRefactory.CSharp;
+
+namespace ICSharpCode.NRefactory.CSharp.Refactoring
+{
+	[TestFixture]
+	public class LambdaHelperTests
+	{
+		RefactoringContext MakeContext(string input, bool expectErrors = false)
+		{
+			var context = TestRefactoringContext.Create(input, expectErrors);
+			return context;
+		}
+
+		[Test]
+		public void TestExtensionMethod()
+		{
+			string input = @"
+using System.Linq;
+class Test
+{
+	void Method() {
+		System.Enumerable<Empty> ().Where(<-i => i > 0->);
+	}
+}
+";
+
+			var context = MakeContext(input);
+			var lambda = context.GetSelectedNodes().OfType<LambdaExpression>().First();
+
+			Assert.IsNotNull(LambdaHelper.GetLambdaReturnType(context, lambda));
+		}
+	}
+}
+


### PR DESCRIPTION
Previously, LambdaHelper did not work properly for extension methods.
This meant that converting a lambda expression to statement or extracting lambda expression to method did not work correctly when the lambda was used as an extension method.

I added an unit test that shows the problem.

This commit also includes a fixed version of LambdaHelper.

All this fix does is skip the first argument if the method is being used as an extension method.
