### PR TITLE
Introduced NamespaceDeclaration.IdentifierTokens (for MonoDevelop compatibility)

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Ast/GeneralScope/NamespaceDeclaration.cs
+++ b/ICSharpCode.NRefactory.CSharp/Ast/GeneralScope/NamespaceDeclaration.cs
@@ -76,15 +76,21 @@ namespace ICSharpCode.NRefactory.CSharp
 
 		public IEnumerable<string> Identifiers {
 			get {
-				var result = new Stack<string>();
+				return IdentifierTokens.Select(token => token.Name);
+			}
+		}
+
+		public IEnumerable<Identifier> IdentifierTokens {
+			get {
+				var result = new Stack<Identifier>();
 				AstType type = NamespaceName;
 				while (type is MemberType) {
 					var mt = (MemberType)type;
-					result.Push(mt.MemberName);
+					result.Push(mt.MemberNameToken);
 					type = mt.Target;
 				}
 				if (type is SimpleType)
-					result.Push(((SimpleType)type).Identifier);
+					result.Push(((SimpleType)type).IdentifierToken);
 				return result;
 			}
 		}


### PR DESCRIPTION
Commit dd43d89be81141a602e3a99c1fda808da2d86933 made Identifiers return an `IEnumerable<string>`, but some MonoDevelop code still expected `IEnumerable<Identifier>`, so I created a new property for that.

See also https://github.com/mono/monodevelop/pull/315
