### PR TITLE
Treat object and dynamic as the same in anonymous function conversions.

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Resolver/CSharpConversions.cs
+++ b/ICSharpCode.NRefactory.CSharp/Resolver/CSharpConversions.cs
@@ -1007,7 +1007,7 @@ namespace ICSharpCode.NRefactory.CSharp.Resolver
 						IParameter pF = f.Parameters[i];
 						if (pD.IsRef != pF.IsRef || pD.IsOut != pF.IsOut)
 							return Conversion.None;
-						if (!dParamTypes[i].Equals(pF.Type))
+						if (!IdentityConversion(dParamTypes[i], pF.Type))
 							return Conversion.None;
 					}
 				}

--- a/ICSharpCode.NRefactory.Tests/CSharp/Resolver/ConversionsTest.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/Resolver/ConversionsTest.cs
@@ -891,6 +891,86 @@ class Test {
 		}
 
 		[Test]
+		public void MethodGroupConversion_ObjectToDynamic() {
+			string program = @"using System;
+class Test {
+	public void F(object o) {}
+	public void M() {
+		Action<dynamic> x = $F$;
+	}
+}";
+			var c = GetConversion(program);
+			Assert.IsTrue(c.IsValid);
+		}
+
+		[Test]
+		public void MethodGroupConversion_ObjectToDynamicGenericArgument() {
+			string program = @"using System;
+using System.Collections.Generic;
+class Test {
+	public void F(List<object> l) {}
+	public void M() {
+		Action<List<dynamic>> x = $F$;
+	}
+}";
+			var c = GetConversion(program);
+			Assert.IsTrue(c.IsValid);
+		}
+
+		[Test]
+		public void MethodGroupConversion_ObjectToDynamicReturnValue() {
+			string program = @"using System;
+class Test {
+	public object F() {}
+	public void M() {
+		Func<dynamic> x = $F$;
+	}
+}";
+			var c = GetConversion(program);
+			Assert.IsTrue(c.IsValid);
+		}
+
+		[Test]
+		public void MethodGroupConversion_DynamicToObject() {
+			string program = @"using System;
+class Test {
+	public void F(dynamic o) {}
+	public void M() {
+		Action<object> x = $F$;
+	}
+}";
+			var c = GetConversion(program);
+			Assert.IsTrue(c.IsValid);
+		}
+
+		[Test]
+		public void MethodGroupConversion_DynamicToObjectGenericArgument() {
+			string program = @"using System;
+using System.Collections.Generic;
+class Test {
+	public void F(List<dynamic> l) {}
+	public void M() {
+		Action<List<object>> x = $F$;
+	}
+}";
+			var c = GetConversion(program);
+			Assert.IsTrue(c.IsValid);
+		}
+
+		[Test]
+		public void MethodGroupConversion_DynamicToObjectReturnValue() {
+			string program = @"using System;
+class Test {
+	public dynamic F() {}
+	public void M() {
+		Func<object> x = $F$;
+	}
+}";
+			var c = GetConversion(program);
+			Assert.IsTrue(c.IsValid);
+		}
+
+		[Test]
 		public void UserDefined_IntLiteral_ViaUInt_ToCustomStruct()
 		{
 			string program = @"using System;

--- a/ICSharpCode.NRefactory.Tests/CSharp/Resolver/LambdaTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/Resolver/LambdaTests.cs
@@ -841,5 +841,55 @@ class Test {
 			Assert.IsTrue(c.IsValid);
 			Assert.IsTrue(c.IsAnonymousFunctionConversion);
 		}
+
+		[Test]
+		public void AnonymousMethodConversionObjectToDynamic() {
+			string program = @"using System;
+class Test {
+	public void M() {
+		Action<dynamic> x = $delegate(object z) { z = null; }$;
+	}
+}";
+			var c = GetConversion(program);
+			Assert.IsTrue(c.IsValid);
+		}
+
+		[Test]
+		public void AnonymousMethodConversionObjectToDynamicGenericArgument() {
+			string program = @"using System;
+using System.Collections.Generic;
+class Test {
+	public void M() {
+		Action<List<dynamic>> x = $delegate(List<object> z) { z = null; }$;
+	}
+}";
+			var c = GetConversion(program);
+			Assert.IsTrue(c.IsValid);
+		}
+
+		[Test]
+		public void AnonymousMethodConversionDynamicToObject() {
+			string program = @"using System;
+class Test {
+	public void M() {
+		Action<object> x = $delegate(dynamic z) { z = null; }$;
+	}
+}";
+			var c = GetConversion(program);
+			Assert.IsTrue(c.IsValid);
+		}
+
+		[Test]
+		public void AnonymousMethodConversionDynamicToObjectGenericArgument() {
+			string program = @"using System;
+using System.Collections.Generic;
+class Test {
+	public void M() {
+		Action<List<object>> x = $delegate(List<dynamic> z) { z = null; }$;
+	}
+}";
+			var c = GetConversion(program);
+			Assert.IsTrue(c.IsValid);
+		}
 	}
 }


### PR DESCRIPTION
This causes code such as `Action<dynamic> a = (object x) => {}` to be allowed. I can't justify this in the spec, but both csc and mcs allow it.

I also added some tests for this conversion in normal method group conversions. Those tests ended up passing, but they probably don't hurt to have.
