### PR TITLE
CS1520 code issue and auto-fix.

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/ICSharpCode.NRefactory.CSharp.csproj
+++ b/ICSharpCode.NRefactory.CSharp/ICSharpCode.NRefactory.CSharp.csproj
@@ -553,6 +553,7 @@
     <Compile Include="Refactoring\CodeIssues\Uncategorized\DisposeMethodInNonIDisposableTypeIssue.cs" />
     <Compile Include="Refactoring\CodeActions\ConvertIfToNullCoalescingAction.cs" />
     <Compile Include="Refactoring\CodeIssues\Synced\CodeQuality\DoNotCallOverridableMethodsInConstructorIssue.cs" />
+    <Compile Include="Refactoring\CodeIssues\Uncategorized\CompilerErrors\CS1520MethodMustHaveAReturnType.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ICSharpCode.NRefactory\ICSharpCode.NRefactory.csproj">

--- a/ICSharpCode.NRefactory.CSharp/Parser/CSharpParser.cs
+++ b/ICSharpCode.NRefactory.CSharp/Parser/CSharpParser.cs
@@ -3749,7 +3749,7 @@ namespace ICSharpCode.NRefactory.CSharp
 			public override void Print (AbstractMessage msg, bool showFullPath)
 			{
 				base.Print (msg, showFullPath);
-				var newError = new Error (msg.IsWarning ? ErrorType.Warning : ErrorType.Error, msg.Text, new DomRegion (fileName, msg.Location.Row, msg.Location.Column));
+				var newError = new Error (msg.IsWarning ? ErrorType.Warning : ErrorType.Error, "CS" + msg.Code, msg.Text, new DomRegion (fileName, msg.Location.Row, msg.Location.Column));
 				Errors.Add (newError);
 			}
 		}

--- a/ICSharpCode.NRefactory.CSharp/Refactoring/BaseRefactoringContext.cs
+++ b/ICSharpCode.NRefactory.CSharp/Refactoring/BaseRefactoringContext.cs
@@ -38,6 +38,7 @@ using ICSharpCode.NRefactory.CSharp.Analysis;
 using ICSharpCode.NRefactory.Utils;
 using System.Collections.Generic;
 using ICSharpCode.NRefactory.Analysis;
+using System.Collections.ObjectModel;
 
 namespace ICSharpCode.NRefactory.CSharp.Refactoring
 {
@@ -45,6 +46,7 @@ namespace ICSharpCode.NRefactory.CSharp.Refactoring
 	{
 		readonly CSharpAstResolver resolver;
 		readonly CancellationToken cancellationToken;
+		readonly List<Error> errorsAndWarnings;
 		
 		public virtual bool Supports(Version version)
 		{
@@ -85,15 +87,23 @@ namespace ICSharpCode.NRefactory.CSharp.Refactoring
 			get { return resolver.Compilation; }
 		}
 
+
+
 		/// <summary>
 		/// Gets the type graph for the current compilation.
 		/// </summary>
 		public virtual TypeGraph TypeGraph {
 			get { return new TypeGraph(Compilation.Assemblies); }
 		}
-		
-		public BaseRefactoringContext (ICSharpCode.NRefactory.CSharp.Resolver.CSharpAstResolver resolver, System.Threading.CancellationToken cancellationToken)
+
+		public ReadOnlyCollection<Error> ErrorsAndWarnings
 		{
+			get { return new ReadOnlyCollection<Error>(errorsAndWarnings); }
+		}
+		
+		public BaseRefactoringContext (ICSharpCode.NRefactory.CSharp.Resolver.CSharpAstResolver resolver, List<Error> errorsAndWarnings, System.Threading.CancellationToken cancellationToken)
+		{
+			this.errorsAndWarnings = new List<Error>(errorsAndWarnings);
 			this.resolver = resolver;
 			this.cancellationToken = cancellationToken;
 			this.referenceFinder = new LocalReferenceFinder(resolver);

--- a/ICSharpCode.NRefactory.CSharp/Refactoring/CodeIssues/Uncategorized/CompilerErrors/CS1520MethodMustHaveAReturnType.cs
+++ b/ICSharpCode.NRefactory.CSharp/Refactoring/CodeIssues/Uncategorized/CompilerErrors/CS1520MethodMustHaveAReturnType.cs
@@ -1,0 +1,82 @@
+//
+// CS1520MethodMustHaveAReturnType.cs
+//
+// Author:
+//       Luís Reis <luiscubal@gmail.com>
+//
+// Copyright (c) 2013 Luís Reis
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using ICSharpCode.NRefactory.CSharp;
+using ICSharpCode.NRefactory.Refactoring;
+using ICSharpCode.NRefactory.TypeSystem;
+
+namespace ICSharpCode.NRefactory.CSharp.Refactoring
+{
+	[IssueDescriptionAttribute("Class, struct or interface method must have a return type",
+	                           Description = "Found method without return type",
+	                           Category = IssueCategories.CompilerErrors,
+	                           Severity = Severity.Error,
+	                           AcceptInvalidContexts = true)]
+	public class CS1520MethodMustHaveAReturnType : ICodeIssueProvider
+	{
+		public IEnumerable<CodeIssue> GetIssues(BaseRefactoringContext context)
+		{
+			foreach (var error in context.ErrorsAndWarnings) {
+				if (error.ErrorType != ErrorType.Error)
+					continue;
+				if (error.ErrorCode != "CS1520")
+					continue;
+
+				var entity = context.RootNode.GetNodeAt<ConstructorDeclaration>(error.Region.Begin);
+				var typeDeclaration = entity.GetParent<TypeDeclaration>();
+
+				var fixActions = new List<CodeAction>();
+
+				fixActions.Add(new CodeAction(context.TranslateString("Make this a void method"), script =>  {
+					var generatedMethod = new MethodDeclaration();
+					generatedMethod.Modifiers = entity.Modifiers;
+					generatedMethod.ReturnType = new PrimitiveType("void");
+					generatedMethod.Name = entity.Name;
+					generatedMethod.Parameters.AddRange(entity.Parameters.Select(parameter => (ParameterDeclaration)parameter.Clone()));
+					generatedMethod.Body = (BlockStatement) entity.Body.Clone();
+					generatedMethod.Attributes.AddRange(entity.Attributes.Select(attribute => (AttributeSection) attribute.Clone()));
+
+					script.Replace(entity, generatedMethod);
+				}, entity));
+
+				fixActions.Add(new CodeAction(context.TranslateString("Make this a constructor"), script =>  {
+					var generatedConstructor = new ConstructorDeclaration();
+					generatedConstructor.Modifiers = entity.Modifiers;
+					generatedConstructor.Name = typeDeclaration.Name;
+					generatedConstructor.Parameters.AddRange(entity.Parameters.Select(parameter => (ParameterDeclaration)parameter.Clone()));
+					generatedConstructor.Body = (BlockStatement) entity.Body.Clone();
+					generatedConstructor.Attributes.AddRange(entity.Attributes.Select(attribute => (AttributeSection) attribute.Clone()));
+
+					script.Replace(entity, generatedConstructor);
+				}, entity));
+
+				yield return new CodeIssue(context.TranslateString("Class, struct or interface method must have a return type"), entity.NameToken.StartLocation, entity.NameToken.EndLocation, fixActions);
+			}
+		}
+	}
+}

--- a/ICSharpCode.NRefactory.CSharp/Refactoring/IssueAttribute.cs
+++ b/ICSharpCode.NRefactory.CSharp/Refactoring/IssueAttribute.cs
@@ -49,6 +49,8 @@ namespace ICSharpCode.NRefactory.CSharp
 
 		public IssueMarker IssueMarker { get; set; }
 
+		public bool AcceptInvalidContexts { get; set; }
+
 		public IssueDescriptionAttribute (string title)
 		{
 			Title = title;

--- a/ICSharpCode.NRefactory.CSharp/Refactoring/RefactoringContext.cs
+++ b/ICSharpCode.NRefactory.CSharp/Refactoring/RefactoringContext.cs
@@ -39,8 +39,9 @@ namespace ICSharpCode.NRefactory.CSharp.Refactoring
 {
 	public abstract class RefactoringContext : BaseRefactoringContext
 	{
-		public RefactoringContext(CSharpAstResolver resolver, CancellationToken cancellationToken) : base  (resolver, cancellationToken)
+		public RefactoringContext(CSharpAstResolver resolver, List<Error> errorsAndWarnings, CancellationToken cancellationToken) : base  (resolver, errorsAndWarnings, cancellationToken)
 		{
+
 		}
 
 		public abstract TextLocation Location { get; }

--- a/ICSharpCode.NRefactory.CSharp/Resolver/FindReferences.cs
+++ b/ICSharpCode.NRefactory.CSharp/Resolver/FindReferences.cs
@@ -535,7 +535,7 @@ namespace ICSharpCode.NRefactory.CSharp.Resolver
 				delegate(AstNode astNode, ResolveResult result) {
 					var nodeToReplace = GetNodeToReplace(astNode);
 					if (nodeToReplace == null) {
-						errorCallback (new Error (ErrorType.Error, "no node to replace found."));
+						errorCallback (new Error (ErrorType.Error, null, "no node to replace found."));
 						return;
 					}
 					callback (new RenameCallbackArguments(nodeToReplace, Identifier.Create(newName)));

--- a/ICSharpCode.NRefactory.Tests/CSharp/CodeActions/TestRefactoringContext.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/CodeActions/TestRefactoringContext.cs
@@ -50,7 +50,7 @@ namespace ICSharpCode.NRefactory.CSharp.CodeActions
 		internal readonly IDocument doc;
 		readonly TextLocation location;
 		
-		public TestRefactoringContext (IDocument document, TextLocation location, CSharpAstResolver resolver) : base(resolver, CancellationToken.None)
+		public TestRefactoringContext (IDocument document, TextLocation location, CSharpAstResolver resolver, List<Error> errorsAndWarnings) : base(resolver, errorsAndWarnings, CancellationToken.None)
 		{
 			this.doc = document;
 			this.location = location;
@@ -284,7 +284,7 @@ namespace ICSharpCode.NRefactory.CSharp.CodeActions
 			TextLocation location = TextLocation.Empty;
 			if (idx >= 0)
 				location = doc.GetLocation (idx);
-			return new TestRefactoringContext(doc, location, resolver) {
+			return new TestRefactoringContext(doc, location, resolver, parser.ErrorsAndWarnings.ToList()) {
 				selectionStart = selectionStart,
 				selectionEnd = selectionEnd
 			};

--- a/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/CS1520MethodMustHaveAReturnTypeTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/CS1520MethodMustHaveAReturnTypeTests.cs
@@ -1,0 +1,77 @@
+//
+// CS1520MethodMustHaveAReturnTypeTests.cs
+//
+// Author:
+//       Luís Reis <luiscubal@gmail.com>
+//
+// Copyright (c) 2013 Luís Reis
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using NUnit.Framework;
+using ICSharpCode.NRefactory.CSharp.Refactoring;
+using ICSharpCode.NRefactory.CSharp.CodeActions;
+using System.Linq;
+
+namespace ICSharpCode.NRefactory.CSharp.CodeIssues
+{
+	[TestFixture]
+	public class CS1520MethodMustHaveAReturnTypeTests : InspectionActionTestBase
+	{
+		[Test]
+		public void TestMethod()
+		{
+			TestRefactoringContext context;
+			var issues = GetIssues(new CS1520MethodMustHaveAReturnType(), @"class Foo
+{
+	static Fa (string str)
+	{
+	}
+}", out context, true);
+
+			Assert.AreEqual(1, issues.Count);
+			CheckFix (context, issues.First(), @"class Foo
+{
+	static void Fa (string str)
+	{
+	}
+}", 0);
+		}
+
+		[Test]
+		public void TestConstructor()
+		{
+			TestRefactoringContext context;
+			var issues = GetIssues(new CS1520MethodMustHaveAReturnType(), @"class Foo
+{
+	internal Fa (string str)
+	{
+	}
+}", out context, true);
+
+			Assert.AreEqual(1, issues.Count);
+			CheckFix (context, issues.First(), @"class Foo
+{
+	internal Foo (string str)
+	{
+	}
+}", 1);
+		}
+	}
+}
+

--- a/ICSharpCode.NRefactory.Tests/ICSharpCode.NRefactory.Tests.csproj
+++ b/ICSharpCode.NRefactory.Tests/ICSharpCode.NRefactory.Tests.csproj
@@ -433,6 +433,7 @@
     <Compile Include="FormattingTests\TestGlobalLevelFormatting.cs" />
     <Compile Include="CSharp\CodeIssues\ConditionalTernaryEqualBranchTests.cs" />
     <Compile Include="CSharp\CodeIssues\ThreadStaticAtInstanceFieldTests.cs" />
+    <Compile Include="CSharp\CodeIssues\CS1520MethodMustHaveAReturnTypeTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\cecil\Mono.Cecil.csproj">

--- a/ICSharpCode.NRefactory/TypeSystem/Error.cs
+++ b/ICSharpCode.NRefactory/TypeSystem/Error.cs
@@ -44,10 +44,16 @@ namespace ICSharpCode.NRefactory.TypeSystem
 	[Serializable]
 	public class Error
 	{
+		readonly string errorCode;
 		readonly ErrorType errorType;
 		readonly string message;
 		readonly DomRegion region;
-		
+
+		/// <summary>
+		/// The error code
+		/// </summary>
+		public string ErrorCode { get { return errorCode; } }
+
 		/// <summary>
 		/// The type of the error.
 		/// </summary>
@@ -69,19 +75,61 @@ namespace ICSharpCode.NRefactory.TypeSystem
 		/// <param name='errorType'>
 		/// The error type.
 		/// </param>
+		/// <param name="errorCode">
+		/// The error code
+		/// </param>
 		/// <param name='message'>
 		/// The description of the error.
 		/// </param>
 		/// <param name='region'>
 		/// The region of the error.
 		/// </param>
-		public Error (ErrorType errorType, string message, DomRegion region)
+		public Error (ErrorType errorType, string errorCode, string message, DomRegion region)
 		{
 			this.errorType = errorType;
+			this.errorCode = errorCode;
 			this.message = message;
 			this.region = region;
 		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ICSharpCode.NRefactory.TypeSystem.Error"/> class.
+		/// </summary>
+		/// <param name='errorType'>
+		/// The error type.
+		/// </param>
+		/// <param name='message'>
+		/// The description of the error.
+		/// </param>
+		/// <param name='region'>
+		/// The region of the error.
+		/// </param>
+		public Error (ErrorType errorType, string message, DomRegion region) : this (errorType, null, message, region)
+		{
+		}
 		
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ICSharpCode.NRefactory.TypeSystem.Error"/> class.
+		/// </summary>
+		/// <param name='errorType'>
+		/// The error type.
+		/// </param>
+		/// <param name="errorCode">
+		/// The error code
+		/// </param>
+		/// <param name='message'>
+		/// The description of the error.
+		/// </param>
+		/// <param name='location'>
+		/// The location of the error.
+		/// </param>
+		public Error (ErrorType errorType, string errorCode, string message, TextLocation location)
+		{
+			this.errorType = errorType;
+			this.message = message;
+			this.region = new DomRegion (location, location);
+		}
+
 		/// <summary>
 		/// Initializes a new instance of the <see cref="ICSharpCode.NRefactory.TypeSystem.Error"/> class.
 		/// </summary>
@@ -94,13 +142,32 @@ namespace ICSharpCode.NRefactory.TypeSystem
 		/// <param name='location'>
 		/// The location of the error.
 		/// </param>
-		public Error (ErrorType errorType, string message, TextLocation location)
+		public Error (ErrorType errorType, string message, TextLocation location) : this (errorType, null, message, location)
 		{
-			this.errorType = errorType;
-			this.message = message;
-			this.region = new DomRegion (location, location);
 		}
 		
+		/// <summary>
+		/// Initializes a new instance of the <see cref="ICSharpCode.NRefactory.TypeSystem.Error"/> class.
+		/// </summary>
+		/// <param name='errorType'>
+		/// The error type.
+		/// </param>
+		/// <param name='errorCode'>
+		/// The error code.
+		/// </param>
+		/// <param name='message'>
+		/// The description of the error.
+		/// </param>
+		/// <param name='line'>
+		/// The line of the error.
+		/// </param>
+		/// <param name='col'>
+		/// The column of the error.
+		/// </param>
+		public Error (ErrorType errorType, string errorCode, string message, int line, int col) : this (errorType, errorCode, message, new TextLocation (line, col))
+		{
+		}
+
 		/// <summary>
 		/// Initializes a new instance of the <see cref="ICSharpCode.NRefactory.TypeSystem.Error"/> class.
 		/// </summary>
@@ -116,7 +183,7 @@ namespace ICSharpCode.NRefactory.TypeSystem
 		/// <param name='col'>
 		/// The column of the error.
 		/// </param>
-		public Error (ErrorType errorType, string message, int line, int col) : this (errorType, message, new TextLocation (line, col))
+		public Error (ErrorType errorType, string message, int line, int col) : this (errorType, null, message, new TextLocation (line, col))
 		{
 		}
 		
@@ -126,14 +193,29 @@ namespace ICSharpCode.NRefactory.TypeSystem
 		/// <param name='errorType'>
 		/// The error type.
 		/// </param>
+		/// <param name="errorCode">
+		/// The error code.
+		/// </param> 
 		/// <param name='message'>
 		/// The description of the error.
 		/// </param>
-		public Error (ErrorType errorType, string message)
+		public Error (ErrorType errorType, string errorCode, string message)
 		{
 			this.errorType = errorType;
+			this.errorCode = errorCode;
 			this.message = message;
 			this.region = DomRegion.Empty;
+		}
+
+		/// </summary>
+		/// <param name='errorType'>
+		/// The error type.
+		/// </param>
+		/// <param name='message'>
+		/// The description of the error.
+		/// </param>
+		public Error (ErrorType errorType, string message) : this(errorType, null, message)
+		{
 		}
 	}
 }


### PR DESCRIPTION
This adds code issues based on actual compiler errors.
I added CS1520MethodMustHaveAReturnTypeIssue.

Previously, issue providers wouldn't even be run for documents with this kind of errors. As such, this will require changes to MonoDevelop (I will send the pull request soon).

First of all, this lets the NRefactory context know about compiler errors.
Additionally, errors now have a field indicating the error code (a string such as `"CS1234"` or `null` for no code).

The issue will detect cases like this:

``` csharp
public class Class1
{
   public NotTheClassName()
   {
   }
}
```

It will then suggest two fixes: Make it a void method, or make it a constructor.

Let me know if there was a better way of doing this.
