### PR TITLE
String.Format refactoring improved

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Refactoring/CodeActions/UseStringFormatAction.cs
+++ b/ICSharpCode.NRefactory.CSharp/Refactoring/CodeActions/UseStringFormatAction.cs
@@ -82,12 +82,11 @@ namespace ICSharpCode.NRefactory.CSharp.Refactoring
 
                             format.Append(QuoteBraces(rawLiteral));
 						} else {
-							var index = IndexOf (arguments, item);
-
-                            Expression myItem = item;
+                            Expression myItem = RemoveUnnecessaryToString(item);
                             string itemFormatStr = DetermineItemFormatString(ref myItem);
-
-							if (index == -1) {
+                            
+                            var index = IndexOf(arguments, myItem);
+                            if (index == -1) {
 								// new item
 								formatInvocation.Arguments.Add (myItem.Clone ());
 								arguments.Add (item);
@@ -109,6 +108,22 @@ namespace ICSharpCode.NRefactory.CSharp.Refactoring
                         script.Replace (expr, formatLiteral);
 				}, node);
 		}
+
+        private Expression RemoveUnnecessaryToString(Expression myItem)
+        {
+            if (myItem is InvocationExpression)
+            {
+                InvocationExpression invocation = (InvocationExpression)myItem;
+                if (invocation.Target is MemberReferenceExpression &&
+                    ((MemberReferenceExpression)invocation.Target).MemberName.Equals("ToString") &&
+                    invocation.Arguments.Count == 0)
+                {
+                    myItem = invocation.Target.FirstChild as Expression;
+                }
+                
+            }
+            return myItem;
+        }
 
         private string QuoteBraces(string rawLiteral)
         {

--- a/ICSharpCode.NRefactory.Tests/CSharp/CodeActions/UseStringFormatTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/CodeActions/UseStringFormatTests.cs
@@ -184,5 +184,27 @@ class TestClass
 }");
         }
 
+        [Test]
+        public void TestUnnecessaryToString()
+        {
+            Test<UseStringFormatAction>(@"
+class TestClass
+{
+	void TestMethod ()
+	{
+        int i = 42;
+		string res = $""String 1"" + i.ToString();
+	}
+}", @"
+class TestClass
+{
+	void TestMethod ()
+	{
+        int i = 42;
+		string res = string.Format (""String 1{0}"", i);
+	}
+}");
+        }
+
 	}
 }


### PR DESCRIPTION
I improved the String.Format refacturing to include format strings of the individual items. This allows to refactor expressions similar to the following statements:

string res = "A number: " + var.Prop.ToString("N2")

===> string res = string.Format("A number: {0:N2}", var.Prop)
