### PR TITLE
Use correct type resolve context when resolving attributes.

### DIFF
--- a/ICSharpCode.NRefactory.Tests/TypeSystem/TypeSystemTests.TestCase.cs
+++ b/ICSharpCode.NRefactory.Tests/TypeSystem/TypeSystemTests.TestCase.cs
@@ -397,4 +397,28 @@ namespace ICSharpCode.NRefactory.TypeSystem.TestCase
 		event Action IExplicitImplementationTests.E { add {} remove {} }
 		int IExplicitImplementationTests.this[int x] { get { return 0; } set {} }
 	}
+
+	[TypeTest(C, typeof(Inner), typeof(int)), My]
+	public class ClassWithAttributesUsingNestedMembers {
+		sealed class MyAttribute : Attribute {}
+
+		const int C = 42;
+		class Inner {
+		}
+
+		[TypeTest(C, typeof(Inner), typeof(int)), My]
+		public int P { get; set; }
+
+		[TypeTest(C, typeof(Inner), typeof(int)), My]
+		class AttributedInner {
+		}
+
+		[TypeTest(C, typeof(Inner), typeof(int)), My]
+		class AttributedInner2 {
+			sealed class MyAttribute : Attribute {}
+
+			const int C = 43;
+			class Inner {}
+		}
+	}
 }

--- a/ICSharpCode.NRefactory.Tests/TypeSystem/TypeSystemTests.cs
+++ b/ICSharpCode.NRefactory.Tests/TypeSystem/TypeSystemTests.cs
@@ -1355,5 +1355,44 @@ namespace ICSharpCode.NRefactory.TypeSystem
 			Assert.That(events.Select(e => e.RemoveAccessor.ImplementedInterfaceMembers.Count).ToList(), Is.EquivalentTo(new[] { 0, 1 }));
 			Assert.AreEqual(events.SelectMany(e => e.RemoveAccessor.ImplementedInterfaceMembers).Single(), ievent.RemoveAccessor);
 		}
+
+		[Test]
+		public void AttributesUsingNestedMembers() {
+			var type = GetTypeDefinition(typeof(ClassWithAttributesUsingNestedMembers));
+			var inner = type.GetNestedTypes().Single(t => t.Name == "Inner");
+			var myAttribute = type.GetNestedTypes().Single(t => t.Name == "MyAttribute");
+			var typeTypeTestAttr = type.Attributes.Single(a => a.AttributeType.Name == "TypeTestAttribute");
+			Assert.AreEqual(42, typeTypeTestAttr.PositionalArguments[0].ConstantValue);
+			Assert.IsInstanceOf<TypeOfResolveResult>(typeTypeTestAttr.PositionalArguments[1]);
+			Assert.AreEqual(inner, ((TypeOfResolveResult)typeTypeTestAttr.PositionalArguments[1]).ReferencedType);
+			var typeMyAttr = type.Attributes.Single(a => a.AttributeType.Name == "MyAttribute");
+			Assert.AreEqual(myAttribute, typeMyAttr.AttributeType);
+
+			var prop = type.GetProperties().Single(p => p.Name == "P");
+			var propTypeTestAttr = prop.Attributes.Single(a => a.AttributeType.Name == "TypeTestAttribute");
+			Assert.AreEqual(42, propTypeTestAttr.PositionalArguments[0].ConstantValue);
+			Assert.IsInstanceOf<TypeOfResolveResult>(propTypeTestAttr.PositionalArguments[1]);
+			Assert.AreEqual(inner, ((TypeOfResolveResult)propTypeTestAttr.PositionalArguments[1]).ReferencedType);
+			var propMyAttr = prop.Attributes.Single(a => a.AttributeType.Name == "MyAttribute");
+			Assert.AreEqual(myAttribute, propMyAttr.AttributeType);
+
+			var attributedInner = (ITypeDefinition)type.GetNestedTypes().Single(t => t.Name == "AttributedInner");
+			var innerTypeTestAttr = attributedInner.Attributes.Single(a => a.AttributeType.Name == "TypeTestAttribute");
+			Assert.AreEqual(42, innerTypeTestAttr.PositionalArguments[0].ConstantValue);
+			Assert.IsInstanceOf<TypeOfResolveResult>(innerTypeTestAttr.PositionalArguments[1]);
+			Assert.AreEqual(inner, ((TypeOfResolveResult)innerTypeTestAttr.PositionalArguments[1]).ReferencedType);
+			var innerMyAttr = attributedInner.Attributes.Single(a => a.AttributeType.Name == "MyAttribute");
+			Assert.AreEqual(myAttribute, innerMyAttr.AttributeType);
+
+			var attributedInner2 = (ITypeDefinition)type.GetNestedTypes().Single(t => t.Name == "AttributedInner2");
+			var inner2 = attributedInner2.GetNestedTypes().Single(t => t.Name == "Inner");
+			var myAttribute2 = attributedInner2.GetNestedTypes().Single(t => t.Name == "MyAttribute");
+			var inner2TypeTestAttr = attributedInner2.Attributes.Single(a => a.AttributeType.Name == "TypeTestAttribute");
+			Assert.AreEqual(43, inner2TypeTestAttr.PositionalArguments[0].ConstantValue);
+			Assert.IsInstanceOf<TypeOfResolveResult>(inner2TypeTestAttr.PositionalArguments[1]);
+			Assert.AreEqual(inner2, ((TypeOfResolveResult)inner2TypeTestAttr.PositionalArguments[1]).ReferencedType);
+			var inner2MyAttr = attributedInner2.Attributes.Single(a => a.AttributeType.Name == "MyAttribute");
+			Assert.AreEqual(myAttribute2, inner2MyAttr.AttributeType);
+		}
 	}
 }

--- a/ICSharpCode.NRefactory/TypeSystem/Implementation/DefaultResolvedTypeDefinition.cs
+++ b/ICSharpCode.NRefactory/TypeSystem/Implementation/DefaultResolvedTypeDefinition.cs
@@ -94,8 +94,9 @@ namespace ICSharpCode.NRefactory.TypeSystem.Implementation
 					return result;
 				}
 				result = new List<IAttribute>();
+				var context = parentContext.WithCurrentTypeDefinition(this);
 				foreach (IUnresolvedTypeDefinition part in parts) {
-					ITypeResolveContext parentContextForPart = part.CreateResolveContext(parentContext);
+					ITypeResolveContext parentContextForPart = part.CreateResolveContext(context);
 					foreach (var attr in part.Attributes) {
 						result.Add(attr.CreateResolvedAttribute(parentContextForPart));
 					}


### PR DESCRIPTION
This makes this compile (as it should):

```
[My(P)]
public class C {
    sealed class MyAttribute : Attribute { public MyAttribute(int x) {} }
    public const int P = 42;
}
```
