### PR TITLE
Fixed query expansion of "from a in arr1 join C b in arr2 ..."

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Parser/CSharpParser.cs
+++ b/ICSharpCode.NRefactory.CSharp/Parser/CSharpParser.cs
@@ -3415,6 +3415,10 @@ namespace ICSharpCode.NRefactory.CSharp
 				var result = new QueryJoinClause ();
 				var location = LocationsBag.GetLocations (join);
 				result.AddChild (new CSharpTokenNode (Convert (join.Location), QueryJoinClause.JoinKeywordRole), QueryJoinClause.JoinKeywordRole);
+
+				if (join.IdentifierType != null)
+					result.AddChild (ConvertToType (join.IdentifierType), QueryJoinClause.TypeRole);
+
 				result.AddChild (Identifier.Create (join.JoinVariable.Name, Convert (join.JoinVariable.Location)), QueryJoinClause.JoinIdentifierRole);
 				
 				if (location != null)

--- a/ICSharpCode.NRefactory.CSharp/QueryExpressionExpander.cs
+++ b/ICSharpCode.NRefactory.CSharp/QueryExpressionExpander.cs
@@ -261,6 +261,9 @@ namespace ICSharpCode.NRefactory.CSharp {
 			public override AstNode VisitQueryJoinClause(QueryJoinClause queryJoinClause) {
 				Expression resultSelectorBody = null;
 				var inExpression = VisitNested(queryJoinClause.InExpression, null);
+				if (!queryJoinClause.Type.IsNull) {
+					inExpression = inExpression.Invoke("Cast", new[] { queryJoinClause.Type.Clone() }, EmptyList<Expression>.Instance);
+				}
 				var key1SelectorFirstParam = CreateParameterForCurrentRangeVariable();
 				var key1Selector = CreateLambda(new[] { key1SelectorFirstParam }, VisitNested(queryJoinClause.OnExpression, key1SelectorFirstParam));
 				var key2Param = CreateParameter(Identifier.Create(queryJoinClause.JoinIdentifier));

--- a/ICSharpCode.NRefactory.Tests/CSharp/QueryExpressionExpanderTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/QueryExpressionExpanderTests.cs
@@ -268,6 +268,23 @@ namespace ICSharpCode.NRefactory.CSharp {
 		}
 
 		[Test]
+		public void JoinWithCast() {
+			var node = ParseUtilCSharp.ParseExpression<QueryExpression>("from i in arr1 join CJ j in arr2 on i.keyi equals j.keyj select i.valuei + j.valuej");
+			var actual = new QueryExpressionExpander().ExpandQueryExpressions(node);
+			AssertCorrect(actual.AstNode, "arr1.Join(arr2.Cast<CJ>(),i=>i.keyi,j=>j.keyj,(i,j)=>i.valuei+j.valuej)");
+			dynamic astNode = actual.AstNode;
+			AssertLookupCorrect(actual.RangeVariables, new[] {
+				Tuple.Create(new TextLocation(1, 6), (AstNode)ElementAt(ElementAt(astNode.Arguments, 1).Parameters, 0)),
+				Tuple.Create(new TextLocation(1, 24), (AstNode)ElementAt(ElementAt(astNode.Arguments, 2).Parameters, 0)),
+			});
+			AssertLookupCorrect(actual.Expressions, new[] {
+				Tuple.Create(new TextLocation(1, 1), (AstNode)astNode.Target.Target),
+				Tuple.Create(new TextLocation(1, 16), (AstNode)astNode),
+				Tuple.Create(new TextLocation(1, 58), (AstNode)astNode),
+			});
+		}
+
+		[Test]
 		public void JoinFollowedByLet() {
 			var node = ParseUtilCSharp.ParseExpression<QueryExpression>("from i in arr1 join j in arr2 on i.keyi equals j.keyj let k = i + j select i + j + k");
 			var actual = new QueryExpressionExpander().ExpandQueryExpressions(node);


### PR DESCRIPTION
This includes a parser fix I found in a29839f606c4194f26b741e13724e6633783b21d.
