### PR TITLE
Implemented 'Redundant partial modifier in method' code issue.

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/ICSharpCode.NRefactory.CSharp.csproj
+++ b/ICSharpCode.NRefactory.CSharp/ICSharpCode.NRefactory.CSharp.csproj
@@ -565,6 +565,7 @@
     <Compile Include="Refactoring\CodeActions\CS1520MethodMustHaveAReturnTypeAction.cs" />
     <Compile Include="Refactoring\CodeIssues\Uncategorized\EmptyDestructorIssue.cs" />
     <Compile Include="Refactoring\CodeIssues\Uncategorized\EmptyNamespaceIssue.cs" />
+    <Compile Include="Refactoring\CodeIssues\Uncategorized\RedundantPartialMethodIssue.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ICSharpCode.NRefactory\ICSharpCode.NRefactory.csproj">

--- a/ICSharpCode.NRefactory.CSharp/Refactoring/CodeIssues/Uncategorized/RedundantPartialMethodIssue.cs
+++ b/ICSharpCode.NRefactory.CSharp/Refactoring/CodeIssues/Uncategorized/RedundantPartialMethodIssue.cs
@@ -1,0 +1,94 @@
+// RedundantPartialMethodIssue.cs
+// 
+// Author:
+//      Luís Reis <luiscubal@gmail.com>
+// 
+// Copyright (c) 2013 Luís Reis
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System.Collections.Generic;
+using System.Linq;
+using ICSharpCode.NRefactory.TypeSystem;
+using ICSharpCode.NRefactory.Refactoring;
+using ICSharpCode.NRefactory.CSharp.Refactoring;
+using ICSharpCode.NRefactory.PatternMatching;
+using Mono.CSharp;
+using ICSharpCode.NRefactory.Semantics;
+
+namespace ICSharpCode.NRefactory.CSharp.Refactoring
+{
+	[IssueDescription ("Redundant partial modifier in method",
+	                   Description = "Redundant partial modifier in method",
+	                   Category = IssueCategories.Redundancies,
+	                   Severity = Severity.Warning,
+	                   IssueMarker = IssueMarker.GrayOut)]
+	public class RedundantPartialMethodIssue : ICodeIssueProvider
+	{
+		public IEnumerable<CodeIssue> GetIssues(BaseRefactoringContext context)
+		{
+			return new GatherVisitor(context).GetIssues();
+		}
+
+		class GatherVisitor : GatherVisitorBase<RedundantPartialMethodIssue>
+		{
+			public GatherVisitor(BaseRefactoringContext ctx)
+				: base(ctx)
+			{
+			}
+
+			public override void VisitMethodDeclaration(MethodDeclaration methodDeclaration)
+			{
+				if (!methodDeclaration.HasModifier(Modifiers.Partial)) {
+					return;
+				}
+
+				var resolveResult = ctx.Resolve(methodDeclaration) as MemberResolveResult;
+				if (resolveResult == null) {
+					return;
+				}
+				var method = (IMethod) resolveResult.Member;
+				if (method == null) {
+					return;
+				}
+
+				if (method.Parts.Count == 1) {
+					AddIssue(methodDeclaration, ctx.TranslateString("Method has redundant partial modifier"),
+					         GetFixAction(methodDeclaration));
+				}
+			}
+
+			public override void VisitBlockStatement(BlockStatement blockStatement)
+			{
+				//We never need to visit the children of block statements
+			}
+
+			CodeAction GetFixAction(MethodDeclaration methodDeclaration)
+			{
+				return new CodeAction(ctx.TranslateString("Remove partial modifier"), script =>
+				{
+					var newDeclaration = (MethodDeclaration)methodDeclaration.Clone();
+					newDeclaration.Modifiers &= ~(Modifiers.Partial);
+
+					script.Replace(methodDeclaration, newDeclaration);
+				}, methodDeclaration);
+			}
+		}
+	}
+}
+

--- a/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/RedundantPartialMethodTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/RedundantPartialMethodTests.cs
@@ -1,0 +1,75 @@
+﻿// 
+// RedundantPartialMethodTests.cs
+// 
+// Author:
+//      Luís Reis <luiscubal@gmail.com>
+// 
+// Copyright (c) 2013 Luís Reis
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using ICSharpCode.NRefactory.CSharp.Refactoring;
+using NUnit.Framework;
+
+namespace ICSharpCode.NRefactory.CSharp.CodeIssues
+{
+	[TestFixture]
+	public class RedundantPartialMethodTests : InspectionActionTestBase
+	{
+		[Test]
+		public void TestRedundantModifier()
+		{
+			var input = @"
+partial class TestClass
+{
+	partial void TestMethod ()
+	{
+		int i = 1;
+	}
+}";
+			var output = @"
+partial class TestClass
+{
+	void TestMethod ()
+	{
+		int i = 1;
+	}
+}";
+			Test<RedundantPartialMethodIssue>(input, 1, output);
+		}
+
+		[Test]
+		public void TestNecessaryModifier()
+		{
+			var input = @"
+partial class TestClass
+{
+	partial void TestMethod ();
+}
+partial class TestClass
+{
+	partial void TestMethod ()
+	{
+		int i = 1;
+	}
+}";
+			Test<RedundantPartialMethodIssue>(input, 0);
+		}
+	}
+}

--- a/ICSharpCode.NRefactory.Tests/ICSharpCode.NRefactory.Tests.csproj
+++ b/ICSharpCode.NRefactory.Tests/ICSharpCode.NRefactory.Tests.csproj
@@ -444,6 +444,7 @@
     <Compile Include="CSharp\CodeActions\CS1520MethodMustHaveAReturnTypeTests.cs" />
     <Compile Include="CSharp\CodeIssues\EmptyDestructorTests.cs" />
     <Compile Include="CSharp\CodeIssues\EmptyNamespaceTests.cs" />
+    <Compile Include="CSharp\CodeIssues\RedundantPartialMethodTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\cecil\Mono.Cecil.csproj">


### PR DESCRIPTION
New code issue. If a method with a body has a `partial` modifier, but there are no other declarations for the same method, then that modifier is redundant and may be removed.
