### PR TITLE
Fixed bug in CS0759RedundantPartialMethodIssue

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Refactoring/CodeIssues/Synced/CompilerWarnings/CS0759RedundantPartialMethodIssue.cs
+++ b/ICSharpCode.NRefactory.CSharp/Refactoring/CodeIssues/Synced/CompilerWarnings/CS0759RedundantPartialMethodIssue.cs
@@ -65,6 +65,9 @@ namespace ICSharpCode.NRefactory.CSharp.Refactoring
 				if (method == null)
 					return;
 
+				if (!method.HasBody)
+					return;
+
 				if (method.Parts.Count == 1) {
 					AddIssue(methodDeclaration.NameToken,
 					         string.Format(ctx.TranslateString("CS0759: A partial method `{0}' implementation is missing a partial method declaration"), method.FullName),

--- a/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/CS0759RedundantPartialMethodIssueTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/CS0759RedundantPartialMethodIssueTests.cs
@@ -55,6 +55,17 @@ partial class TestClass
 		}
 
 		[Test]
+		public void TestMethodWithNoBody()
+		{
+			var input = @"
+partial class TestClass
+{
+	partial void TestMethod ();
+}";
+			Test<CS0759RedundantPartialMethodIssue>(input, 0);
+		}
+
+		[Test]
 		public void TestNecessaryModifier()
 		{
 			var input = @"


### PR DESCRIPTION
Previously, this case was detected:

``` csharp
partial class TestClass
{
    partial void TestMethod();
}
```

And the proposed fix was this:

``` csharp
partial class TestClass
{
    void TestMethod();
}
```

which is wrong.

Now, the issue is simply disabled when the method has no body.
