### PR TITLE
Fixed PartialTypeWithSinglePartIssue to handle partial nested types with non-partial parents.

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Refactoring/CodeIssues/Synced/RedundanciesInDeclaration/PartialTypeWithSinglePartIssue.cs
+++ b/ICSharpCode.NRefactory.CSharp/Refactoring/CodeIssues/Synced/RedundanciesInDeclaration/PartialTypeWithSinglePartIssue.cs
@@ -55,8 +55,11 @@ namespace ICSharpCode.NRefactory.CSharp.Refactoring
 
 			public override void VisitTypeDeclaration(TypeDeclaration typeDeclaration)
 			{
-				if (!typeDeclaration.HasModifier(Modifiers.Partial))
+				if (!typeDeclaration.HasModifier(Modifiers.Partial)) {
+					//We still need to visit the children in search of partial nested types.
+					base.VisitTypeDeclaration(typeDeclaration);
 					return;
+				}
 
 				var resolveResult = ctx.Resolve(typeDeclaration) as TypeResolveResult;
 				if (resolveResult == null)

--- a/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/PartialTypeWithSinglePartIssueTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/PartialTypeWithSinglePartIssueTests.cs
@@ -97,6 +97,26 @@ partial class TestClass
 		}
 
 		[Test]
+		public void TestRedundantNestedPartialInNonPartialOuterClass()
+		{
+			var input = @"
+class TestClass
+{
+	partial class Nested
+	{
+	}
+}";
+			var output = @"
+class TestClass
+{
+	class Nested
+	{
+	}
+}";
+			Test<PartialTypeWithSinglePartIssue>(input, output);
+		}
+
+		[Test]
 		public void TestRedundantNestedPartialDisable()
 		{
 			var input = @"


### PR DESCRIPTION
The new unit test shows the old (now fixed) bug.
