### PR TITLE
Fixed problem converting assembly attributes in the IKVM loader.

### DIFF
--- a/ICSharpCode.NRefactory.IKVM/IkvmLoader.cs
+++ b/ICSharpCode.NRefactory.IKVM/IkvmLoader.cs
@@ -125,6 +125,9 @@ namespace ICSharpCode.NRefactory.TypeSystem
 			if (assembly == null)
 				throw new ArgumentNullException ("assembly");
 
+			currentAssemblyDefinition = assembly;
+			currentAssembly = new IkvmUnresolvedAssembly (assembly.FullName, DocumentationProvider);
+
 			// Read assembly and module attributes
 			IList<IUnresolvedAttribute> assemblyAttributes = new List<IUnresolvedAttribute>();
 			IList<IUnresolvedAttribute> moduleAttributes = new List<IUnresolvedAttribute>();
@@ -134,8 +137,6 @@ namespace ICSharpCode.NRefactory.TypeSystem
 			assemblyAttributes = interningProvider.InternList(assemblyAttributes);
 			moduleAttributes = interningProvider.InternList(moduleAttributes);
 
-			currentAssemblyDefinition = assembly;
-			currentAssembly = new IkvmUnresolvedAssembly (assembly.FullName, DocumentationProvider);
 			currentAssembly.Location = assembly.Location;
 			currentAssembly.AssemblyAttributes.AddRange(assemblyAttributes);
 			currentAssembly.ModuleAttributes.AddRange(moduleAttributes);


### PR DESCRIPTION
If we had

Assembly1:

```
public class MyAttribute {}
```

Assembly2:

```
[assembly: MyAttribute]
```

and we then tried to load Assembly2 with the IKVM loader, the loader would think that the attribute MyAttribute is defined in Assembly2 insteadof Assembly1. This would later cause the resolver to fail to resolve the attribute.

@dgrunwald, @mkrueger: Can you please take a look at this asap? The fix does solve my problem (erik-kallen/SaltarelleCompiler#232) and it doesn't cause any test failures; neither in NRefactory nor in my project, but it looks like it was a conscious decision to write the code as it was. The problem manifested itself on line 313 (in IkvmLoader.cs)
