### PR TITLE
LockThisIssue: Don't underline the whole node, just the lock (this) portion

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Refactoring/CodeIssues/Custom/LockThisIssue.cs
+++ b/ICSharpCode.NRefactory.CSharp/Refactoring/CodeIssues/Custom/LockThisIssue.cs
@@ -95,7 +95,8 @@ namespace ICSharpCode.NRefactory.CSharp.Refactoring
 
 					}, lockStatement);
 
-					AddIssue(lockStatement, ctx.TranslateString("Found lock (this)"), fixAction);
+					AddIssue(lockStatement.LockToken.StartLocation,
+					         lockStatement.RParToken.EndLocation, ctx.TranslateString("Found lock (this)"), fixAction);
 				}
 			}
 


### PR DESCRIPTION
Exactly what it says in the title. Instead of underlining the whole thing (including blocks and tons of statements), just underline lock (this).

Btw: mkrueger, you forgot to add a file (related to your underscore change).
