### PR TITLE
ReplaceWithStringIsNullOrEmptyIssue now detects `x == string.Empty`

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Refactoring/CodeIssues/Synced/PracticesAndImprovements/ReplaceWithStringIsNullOrEmptyIssue.cs
+++ b/ICSharpCode.NRefactory.CSharp/Refactoring/CodeIssues/Synced/PracticesAndImprovements/ReplaceWithStringIsNullOrEmptyIssue.cs
@@ -50,6 +50,8 @@ namespace ICSharpCode.NRefactory.CSharp.Refactoring
 				BinaryOperatorType.ConditionalOr,
 				new Choice {
 					PatternHelper.CommutativeOperator (new Backreference ("str"), BinaryOperatorType.Equality, new PrimitiveExpression ("")),
+					PatternHelper.CommutativeOperator (new Backreference ("str"), BinaryOperatorType.Equality,
+				                                       new MemberReferenceExpression(new TypeReferenceExpression(new PrimitiveType("string")), "Empty")),
 					PatternHelper.CommutativeOperator (
 						new MemberReferenceExpression (new Backreference ("str"), "Length"),
 						BinaryOperatorType.Equality,
@@ -59,7 +61,11 @@ namespace ICSharpCode.NRefactory.CSharp.Refactoring
 			),
 			// str == "" || str == null
 			new BinaryOperatorExpression (
-				PatternHelper.CommutativeOperator (new AnyNode ("str"), BinaryOperatorType.Equality, new PrimitiveExpression ("")),
+				new Choice {
+					PatternHelper.CommutativeOperator (new AnyNode ("str"), BinaryOperatorType.Equality, new PrimitiveExpression ("")),
+					PatternHelper.CommutativeOperator (new AnyNode ("str"), BinaryOperatorType.Equality,
+				                                       new MemberReferenceExpression(new TypeReferenceExpression(new PrimitiveType("string")), "Empty"))
+				},
 				BinaryOperatorType.ConditionalOr,
 				PatternHelper.CommutativeOperator(new Backreference ("str"), BinaryOperatorType.Equality, new NullReferenceExpression ())
 			)
@@ -73,6 +79,8 @@ namespace ICSharpCode.NRefactory.CSharp.Refactoring
 				BinaryOperatorType.ConditionalAnd,
 				new Choice {
 					PatternHelper.CommutativeOperator (new Backreference ("str"), BinaryOperatorType.InEquality, new PrimitiveExpression ("")),
+					PatternHelper.CommutativeOperator (new Backreference ("str"), BinaryOperatorType.InEquality,
+				                                   	   new MemberReferenceExpression(new TypeReferenceExpression(new PrimitiveType("string")), "Empty")),
 					PatternHelper.CommutativeOperator (
 						new MemberReferenceExpression (new Backreference ("str"), "Length"),
 						BinaryOperatorType.InEquality,
@@ -87,7 +95,11 @@ namespace ICSharpCode.NRefactory.CSharp.Refactoring
 			),
 			// str != "" && str != null
 			new BinaryOperatorExpression (
-				PatternHelper.CommutativeOperator (new AnyNode ("str"), BinaryOperatorType.InEquality, new PrimitiveExpression ("")),
+				new Choice {
+					PatternHelper.CommutativeOperator (new AnyNode ("str"), BinaryOperatorType.InEquality, new PrimitiveExpression ("")),
+					PatternHelper.CommutativeOperator (new AnyNode ("str"), BinaryOperatorType.Equality,
+				                                   	   new MemberReferenceExpression(new TypeReferenceExpression(new PrimitiveType("string")), "Empty"))
+				},
 				BinaryOperatorType.ConditionalAnd,
 				PatternHelper.CommutativeOperator(new Backreference ("str"), BinaryOperatorType.InEquality, new NullReferenceExpression ())
 			)

--- a/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/ReplaceWithStringIsNullOrEmptyIssueTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/ReplaceWithStringIsNullOrEmptyIssueTests.cs
@@ -86,6 +86,56 @@ namespace ICSharpCode.NRefactory.CSharp.CodeIssues
 		}
 
 		[Test]
+		public void TestInspectorNegatedStringEmpty ()
+		{
+			var input = @"class Foo
+{
+	void Bar (string str)
+	{
+		if (null != str && str != string.Empty)
+			;
+	}
+}";
+
+			TestRefactoringContext context;
+			var issues = GetIssues (new ReplaceWithStringIsNullOrEmptyIssue (), input, out context);
+			Assert.AreEqual (1, issues.Count);
+			CheckFix (context, issues, @"class Foo
+{
+	void Bar (string str)
+	{
+		if (!string.IsNullOrEmpty (str))
+			;
+	}
+}");
+		}
+
+		[Test]
+		public void TestInspectorStringEmpty ()
+		{
+			var input = @"class Foo
+{
+	void Bar (string str)
+	{
+		if (null == str || str == string.Empty)
+			;
+	}
+}";
+
+			TestRefactoringContext context;
+			var issues = GetIssues (new ReplaceWithStringIsNullOrEmptyIssue (), input, out context);
+			Assert.AreEqual (1, issues.Count);
+			CheckFix (context, issues, @"class Foo
+{
+	void Bar (string str)
+	{
+		if (string.IsNullOrEmpty (str))
+			;
+	}
+}");
+		}
+
+		[Test]
 		public void TestInspectorCaseNS3 ()
 		{
 			var input = @"class Foo


### PR DESCRIPTION
Previously, the issue would detect `x == null || x == ""` but not `x == null || x == string.Empty`.
This commit changes that.

This is a very simple change. For instance, it does not detect `x == System.String.Empty` and `x == SomeConstThatHappensToBeAnEmptyString`.
