### PR TITLE
Fixed FunctionNeverReturnsIssue

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Analysis/ReachabilityAnalysis.cs
+++ b/ICSharpCode.NRefactory.CSharp/Analysis/ReachabilityAnalysis.cs
@@ -150,6 +150,13 @@ namespace ICSharpCode.NRefactory.CSharp.Analysis
 				return foundDefault;
 			}
 
+			public override bool VisitBlockStatement(BlockStatement blockStatement)
+			{
+				//If the block has a recursive statement, then that statement will be visited
+				//individually by the CFG construction algorithm later.
+				return false;
+			}
+
 			protected override bool VisitChildren(AstNode node)
 			{
 				return VisitNodeList(node.Children);

--- a/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/FunctionNeverReturnsIssueTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/FunctionNeverReturnsIssueTests.cs
@@ -89,6 +89,21 @@ class TestClass
 		}
 
 		[Test]
+		public void TestIfWithoutElse ()
+		{
+			var input = @"
+class TestClass
+{
+	string TestMethod (int x)
+	{
+		if (x <= 0) return ""Hi"";
+		return ""_"" + TestMethod(x - 1);
+	}
+}";
+			TestWrongContext<FunctionNeverReturnsIssue> (input);
+		}
+
+		[Test]
 		public void TestRecursive ()
 		{
 			var input = @"


### PR DESCRIPTION
The example

``` csharp
string Foo(int x) {
   if (x <= 0) return "Hi";
   return "_" + Foo(x - 1);
}
``´

is now handled correctly.
The problem was that the program considered block statements to be recursive if *anything* in them was.
```
