### PR TITLE
Fixed issue involving method type parameter constraints

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Resolver/OverloadResolution.cs
+++ b/ICSharpCode.NRefactory.CSharp/Resolver/OverloadResolution.cs
@@ -523,10 +523,7 @@ namespace ICSharpCode.NRefactory.CSharp.Resolver
 					return false;
 			}
 			foreach (IType constraintType in typeParameter.DirectBaseTypes) {
-				IType c = constraintType;
-				if (substitution != null)
-					c = c.AcceptVisitor(substitution);
-				if (!conversions.IsConstraintConvertible(typeArgument, c))
+				if (!conversions.IsConstraintConvertible(typeArgument, constraintType))
 					return false;
 			}
 			return true;

--- a/ICSharpCode.NRefactory.Tests/CSharp/Resolver/InvocationTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/Resolver/InvocationTests.cs
@@ -798,5 +798,22 @@ public class B<T> {
 			Assert.IsFalse(rr.IsError);
 			Assert.AreEqual("System.Int32", rr.Member.ReturnType.FullName);
 		}
+
+		[Test]
+		public void GenericInvocationWithTypeArgumentAsICollection() {
+			string program = @"
+using System;
+using System.Collections.Generic;
+
+static class C1 {
+	public static void G<TC, TI>(TC items) where TC : ICollection<TI> {}
+
+	public static void M<TI>(TI[] items) {
+		$G<TI[], TI>(items)$;
+	}
+}";
+			var rr = Resolve<CSharpInvocationResolveResult>(program);
+			Assert.IsFalse(rr.IsError);
+		}
 	}
 }


### PR DESCRIPTION
An attempt to solve #266, although I am not 100% sure. It seems that the substitution was applied twice. At least this commit solves the problem, and it does not cause any tests to fail.
