### PR TITLE
UseOfMemberOfNullReferenceIssue: Warn that ((Foo)null).Bar() will cause a NRE

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/ICSharpCode.NRefactory.CSharp.csproj
+++ b/ICSharpCode.NRefactory.CSharp/ICSharpCode.NRefactory.CSharp.csproj
@@ -599,6 +599,7 @@
     <Compile Include="Refactoring\CodeActions\AbstractAndVirtualConversionAction.cs" />
     <Compile Include="Refactoring\CodeIssues\NotWorking\DuplicateExpressionsInConditionsIssue.cs" />
     <Compile Include="Refactoring\CodeIssues\Synced\RedundanciesInCode\RedundantToStringCallForValueTypesIssue.cs" />
+    <Compile Include="Refactoring\CodeIssues\Uncategorized\UseOfMemberOfNullReference.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ICSharpCode.NRefactory\ICSharpCode.NRefactory.csproj">

--- a/ICSharpCode.NRefactory.CSharp/Refactoring/CodeIssues/Synced/RedundanciesInCode/ConstantNullCoalescingConditionIssue.cs
+++ b/ICSharpCode.NRefactory.CSharp/Refactoring/CodeIssues/Synced/RedundanciesInCode/ConstantNullCoalescingConditionIssue.cs
@@ -121,22 +121,22 @@ namespace ICSharpCode.NRefactory.CSharp.Refactoring
 				cachedNullAnalysis [parentFunction] = analysis;
 				return analysis;
 			}
+		}
 
-			static AstNode GetParentFunctionNode(AstNode node)
-			{
-				do {
-					node = node.Parent;
-				} while (node != null && !IsFunctionNode(node));
+		public static AstNode GetParentFunctionNode(AstNode node)
+		{
+			do {
+				node = node.Parent;
+			} while (node != null && !IsFunctionNode(node));
 
-				return node;
-			}
+			return node;
+		}
 
-			static bool IsFunctionNode(AstNode node)
-			{
-				return node is EntityDeclaration ||
-					node is LambdaExpression ||
+		static bool IsFunctionNode(AstNode node)
+		{
+			return node is EntityDeclaration ||
+				node is LambdaExpression ||
 					node is AnonymousMethodExpression;
-			}
 		}
 	}
 }

--- a/ICSharpCode.NRefactory.CSharp/Refactoring/CodeIssues/Uncategorized/UseOfMemberOfNullReference.cs
+++ b/ICSharpCode.NRefactory.CSharp/Refactoring/CodeIssues/Uncategorized/UseOfMemberOfNullReference.cs
@@ -1,0 +1,104 @@
+//
+// UseOfMemberInNullReference.cs
+//
+// Author:
+//       Luís Reis <luiscubal@gmail.com>
+//
+// Copyright (c) 2013 Luís Reis
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using ICSharpCode.NRefactory.TypeSystem;
+using ICSharpCode.NRefactory.Semantics;
+using System.Linq;
+using ICSharpCode.NRefactory.Refactoring;
+using ICSharpCode.NRefactory.CSharp.Resolver;
+using ICSharpCode.NRefactory.CSharp.Analysis;
+
+namespace ICSharpCode.NRefactory.CSharp.Refactoring
+{
+	[IssueDescription("Use of (non-extension method) member of null value will cause a NullReferenceException",
+	                  Description = "Detects when a member of a null value is used",
+	                  Category = IssueCategories.CodeQualityIssues,
+	                  Severity = Severity.Warning,
+	                  IssueMarker = IssueMarker.WavedLine)]
+	public class UseOfMemberOfNullReference : GatherVisitorCodeIssueProvider
+	{
+		protected override IGatherVisitor CreateVisitor(BaseRefactoringContext context)
+		{
+			return new GatherVisitor(context);
+		}
+
+		class GatherVisitor : GatherVisitorBase<UseOfMemberOfNullReference>
+		{
+			Dictionary<AstNode, NullValueAnalysis> cachedNullAnalysis = new Dictionary<AstNode, NullValueAnalysis>();
+
+			internal GatherVisitor(BaseRefactoringContext ctx): base(ctx) {}
+
+			public override void VisitMemberReferenceExpression(MemberReferenceExpression memberReferenceExpression)
+			{
+				IMember member = GetMember(memberReferenceExpression);
+				if (member == null || member.IsStatic) {
+					base.VisitMemberReferenceExpression(memberReferenceExpression);
+					return;
+				}
+
+				var parentFunction = ConstantNullCoalescingConditionIssue.GetParentFunctionNode(memberReferenceExpression);
+				var analysis = GetAnalysis(parentFunction);
+
+				if (analysis.GetExpressionResult(memberReferenceExpression.Target) == NullValueStatus.DefinitelyNull) {
+					//Depending on how reliable the null analysis turns out to be, we may also want to include PotentiallyNull here
+
+					AddIssue(memberReferenceExpression,
+					         ctx.TranslateString("Using member of null value will cause a NullReferenceException"));
+				}
+			}
+
+			IMember GetMember(AstNode expression)
+			{
+				var resolveResult = ctx.Resolve(expression);
+				MemberResolveResult memberResolveResult = resolveResult as MemberResolveResult;
+				if (memberResolveResult != null) {
+					return memberResolveResult.Member;
+				}
+
+				var methodGroupResolveResult = resolveResult as MethodGroupResolveResult;
+				if (methodGroupResolveResult != null && expression.Parent is InvocationExpression) {
+					return GetMember(expression.Parent);
+				}
+
+				return null;
+			}
+
+			NullValueAnalysis GetAnalysis(AstNode parentFunction)
+			{
+				NullValueAnalysis analysis;
+				if (cachedNullAnalysis.TryGetValue(parentFunction, out analysis)) {
+					return analysis;
+				}
+
+				analysis = new NullValueAnalysis(ctx, parentFunction.GetChildByRole(Roles.Body), parentFunction.GetChildrenByRole(Roles.Parameter), ctx.CancellationToken);
+				cachedNullAnalysis [parentFunction] = analysis;
+				return analysis;
+			}
+		}
+	}
+}
+

--- a/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/UseOfMemberOfNullReferenceTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/UseOfMemberOfNullReferenceTests.cs
@@ -1,0 +1,98 @@
+﻿// 
+// UseOfMemberOfNullReferenceTests.cs
+// 
+// Author:
+//      Luís Reis <luiscubal@gmail.com>
+// 
+// Copyright (c) 2013 Luís Reis
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using ICSharpCode.NRefactory.CSharp.CodeActions;
+using ICSharpCode.NRefactory.CSharp.Refactoring;
+using NUnit.Framework;
+
+namespace ICSharpCode.NRefactory.CSharp.CodeIssues
+{
+	public class UseOfMemberOfNullReferenceTests : InspectionActionTestBase
+	{
+		[Test]
+		public void TestSimple ()
+		{
+			string input = @"
+class TestClass
+{
+	void TestMethod() {
+		string x = null;
+		return x.Length;
+	}
+}";
+			Test<UseOfMemberOfNullReference> (input, 1);
+		}
+
+		[Test]
+		public void TestDisabledForNonNull ()
+		{
+			string input = @"
+class TestClass
+{
+	void TestMethod() {
+		string x = """";
+		return x.Length;
+	}
+}";
+			TestWrongContext<UseOfMemberOfNullReference> (input);
+		}
+
+		[Test]
+		public void TestMethodGroup ()
+		{
+			string input = @"
+static class X {
+	static void Clone(this string x, int i) {}
+}
+class TestClass
+{
+	void TestMethod() {
+		string x = null;
+		return x.Clone();
+	}
+}";
+			Test<UseOfMemberOfNullReference> (input, 1);
+		}
+
+		[Test]
+		public void TestDisabledForExtensionMethods ()
+		{
+			string input = @"
+static class X
+{
+	static void Foo(this string x) {}
+}
+class TestClass
+{
+	void TestMethod() {
+		string x = """";
+		return x.Foo();
+	}
+}";
+			TestWrongContext<UseOfMemberOfNullReference> (input);
+		}
+	}
+}

--- a/ICSharpCode.NRefactory.Tests/ICSharpCode.NRefactory.Tests.csproj
+++ b/ICSharpCode.NRefactory.Tests/ICSharpCode.NRefactory.Tests.csproj
@@ -479,6 +479,7 @@
     <Compile Include="CSharp\CodeActions\ChangeAccessModifierTests.cs" />
     <Compile Include="CSharp\CodeActions\AbstractAndVirtualConversionActionTests.cs" />
     <Compile Include="CSharp\CodeIssues\RedundantToStringCallForValueTypesIssue.cs" />
+    <Compile Include="CSharp\CodeIssues\UseOfMemberOfNullReferenceTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\cecil\Mono.Cecil.csproj">


### PR DESCRIPTION
This will warn about:

``` csharp
int Foo(string x) {
   if (x != null) x = null;
   return x.Length;
}
```

This relies on the null value analysis. Right now this issue is very conservative, but depending on how good the null value analysis turns out to be, we could make it a bit more aggressive later.
