### PR TITLE
Two failing tests involving type inference when a type is implicitly con...

### DIFF
--- a/ICSharpCode.NRefactory.Tests/CSharp/Resolver/TypeInferenceTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/Resolver/TypeInferenceTests.cs
@@ -602,5 +602,47 @@ class C : I<string>
 			Assert.AreEqual("System.String", mrr.Type.FullName);
 			Assert.IsFalse(mrr.IsError);
 		}
+
+		[Test]
+		public void GenericArgumentImplicitlyConvertibleToAndFromAnotherTypeList() {
+			string program = @"
+using System.Collections.Generic;
+public class MyConvertible {
+	public static implicit operator MyConvertible(int number) { return null; }
+	public static implicit operator int(MyConvertible obj) { return 0; }
+}
+
+class C {
+	public static void F<K>(IList<K> a, K b) {
+	}
+	void M() {
+		$F(new List<MyConvertible>(), 1)$;
+	}
+}";
+			var rr = Resolve<CSharpInvocationResolveResult>(program);
+			Assert.IsFalse(rr.IsError);
+			Assert.That(rr.Member, Is.InstanceOf<SpecializedMethod>());
+			Assert.That(((SpecializedMethod)rr.Member).TypeArguments.Select(ta => ta.FullName), Is.EqualTo(new[] { "MyConvertible" }));
+		}
+
+		[Test]
+		public void GenericArgumentImplicitlyConvertibleToAndFromAnotherTypeIEnumerable() {
+			string program = @"
+using System.Collections.Generic;
+public class MyConvertible {
+	public static implicit operator MyConvertible(int number) { return null; }
+	public static implicit operator int(MyConvertible obj) { return 0; }
+}
+
+class C {
+	public static void F<K>(IEnumerable<K> a, K b) {
+	}
+	void M() {
+		$F(new List<MyConvertible>(), 1)$;
+	}
+}";
+			var rr = Resolve<CSharpInvocationResolveResult>(program);
+			Assert.IsTrue(rr.IsError);
+		}
 	}
 }


### PR DESCRIPTION
...vertible both to and from another type.

Note that the `List<T>` case is supposed to resolve without an error, but the `IEnumerable<T>` case is supposed to give an error. I do not understand why it is so (perhaps something with generic variance; though I thought that only involved identity conversions), but the behavior is the same in both mcs and csc.
