### PR TITLE
Improved Null analysis

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Refactoring/CodeIssues/Uncategorized/UseOfMemberOfNullReference.cs
+++ b/ICSharpCode.NRefactory.CSharp/Refactoring/CodeIssues/Uncategorized/UseOfMemberOfNullReference.cs
@@ -41,6 +41,11 @@ namespace ICSharpCode.NRefactory.CSharp.Refactoring
 	                  IssueMarker = IssueMarker.WavedLine)]
 	public class UseOfMemberOfNullReference : GatherVisitorCodeIssueProvider
 	{
+		static readonly ISet<NullValueStatus> ProblematicNullStates = new HashSet<NullValueStatus> {
+			NullValueStatus.DefinitelyNull,
+			NullValueStatus.PotentiallyNull
+		};
+
 		protected override IGatherVisitor CreateVisitor(BaseRefactoringContext context)
 		{
 			return new GatherVisitor(context);
@@ -63,7 +68,8 @@ namespace ICSharpCode.NRefactory.CSharp.Refactoring
 				var parentFunction = ConstantNullCoalescingConditionIssue.GetParentFunctionNode(memberReferenceExpression);
 				var analysis = GetAnalysis(parentFunction);
 
-				if (analysis.GetExpressionResult(memberReferenceExpression.Target) == NullValueStatus.DefinitelyNull) {
+				var nullStatus = analysis.GetExpressionResult(memberReferenceExpression.Target);
+				if (ProblematicNullStates.Contains(nullStatus)) {
 					//Depending on how reliable the null analysis turns out to be, we may also want to include PotentiallyNull here
 
 					AddIssue(memberReferenceExpression,

--- a/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/UseOfMemberOfNullReferenceTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/UseOfMemberOfNullReferenceTests.cs
@@ -96,7 +96,7 @@ class TestClass
 			TestWrongContext<UseOfMemberOfNullReference> (input);
 		}
 
-		[Ignore("Fixme")]
+		[Ignore("Under discussion")]
 		[Test]
 		public void TestAs ()
 		{
@@ -110,7 +110,6 @@ class TestClass
 			Test<UseOfMemberOfNullReference> (input, 1);
 		}
 
-		[Ignore("Fixme")]
 		[Test]
 		public void TestIfBranch ()
 		{
@@ -127,7 +126,6 @@ class TestClass
 			Test<UseOfMemberOfNullReference> (input, 1);
 		}
 
-		[Ignore("Fixme")]
 		[Test]
 		public void TestSwitchBranch ()
 		{
@@ -152,7 +150,6 @@ class TestClass
 			Test<UseOfMemberOfNullReference> (input, 1);
 		}
 
-		[Ignore("Fixme")]
 		[Test]
 		public void TestWhile ()
 		{


### PR DESCRIPTION
Fixed a bug, added a missing GetHashCode method and added early switch statement support.
Also, the null member reference issue now complains about PotentiallyNull.

Some previously ignored tests are now enabled and working.
TestAs still doesn't work. I'm still not sure it's a good idea to remove the "Unknown" value, because of "x.y.z" (in that case, even if y is a property that's known not to be null, then it would _still_ warn about it.
Of course, we could always just make "as" return "PotentiallyNull" and the member access return "Unknown"...
