### PR TITLE
Added a property Resources to IAssembly and IUnresolvedAssembly.

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/CSharpProjectContent.cs
+++ b/ICSharpCode.NRefactory.CSharp/CSharpProjectContent.cs
@@ -248,16 +248,25 @@ namespace ICSharpCode.NRefactory.CSharp
 			return RemoveFiles((IEnumerable<string>)fileNames);
 		}
 
-		public IProjectContent AddLinkedResource(string name, string filename, bool isPublic = true) {
+		public IProjectContent AddResources(IEnumerable<IAssemblyResource> resources) {
 			var pc = Clone();
-			pc.resources.Add(new LinkedResource(name, Path.GetFileName(filename), Path.GetDirectoryName(filename), isPublic));
+			pc.resources.AddRange(resources);
 			return pc;
 		}
 
-		public IProjectContent AddEmbeddedResource(string name, string filepath, bool isPublic = true) {
-			var pc = Clone();
-			pc.resources.Add(new EmbeddedResource(name, filepath, isPublic));
+		public IProjectContent AddResources(params IAssemblyResource[] resources) {
+			return AddResources((IEnumerable<IAssemblyResource>)resources);
+		}
+
+		public IProjectContent RemoveResources(IEnumerable<IAssemblyResource> resources) {
+			CSharpProjectContent pc = Clone();
+			foreach (var r in resources)
+				pc.resources.Remove(r);
 			return pc;
+		}
+
+		public IProjectContent RemoveResources(params IAssemblyResource[] resources) {
+			return RemoveResources((IEnumerable<IAssemblyResource>)resources);
 		}
 
 		[Obsolete("Use RemoveFiles/AddOrUpdateFiles instead")]
@@ -305,31 +314,6 @@ namespace ICSharpCode.NRefactory.CSharp
 			} else {
 				asm = new CSharpAssembly(context.Compilation, this);
 				return (IAssembly)cache.GetOrAddShared(this, asm);
-			}
-		}
-
-		[Serializable]
-		class EmbeddedResource : IAssemblyResource {
-			private readonly string name;
-			private readonly string filepath;
-			private readonly bool isPublic;
-
-			public string Name { get { return name; } }
-
-			public string LinkedFileName { get { return null; } }
-
-			public AssemblyResourceType Type { get { return AssemblyResourceType.Embedded; } }
-
-			public bool IsPublic { get { return isPublic; } }
-
-			public EmbeddedResource(string name, string filepath, bool isPublic) {
-				this.name = name;
-				this.filepath = filepath;
-				this.isPublic = isPublic;
-			}
-
-			public Stream GetResourceStream() {
-				return File.Open(filepath, FileMode.Open, FileAccess.Read);
 			}
 		}
 	}

--- a/ICSharpCode.NRefactory.CSharp/TypeSystem/CSharpAssembly.cs
+++ b/ICSharpCode.NRefactory.CSharp/TypeSystem/CSharpAssembly.cs
@@ -69,6 +69,12 @@ namespace ICSharpCode.NRefactory.CSharp.TypeSystem
 				return GetAttributes(ref moduleAttributes, false);
 			}
 		}
+
+		public IEnumerable<IAssemblyResource> Resources {
+			get {
+				return projectContent.Resources;
+			}
+		}
 		
 		IList<IAttribute> GetAttributes(ref IList<IAttribute> field, bool assemblyAttributes)
 		{

--- a/ICSharpCode.NRefactory.Cecil/CecilLoader.cs
+++ b/ICSharpCode.NRefactory.Cecil/CecilLoader.cs
@@ -311,8 +311,8 @@ namespace ICSharpCode.NRefactory.TypeSystem
 			public bool IsPublic { get { return isPublic; } }
 
 			public Stream GetResourceStream() {
-				var asm = AssemblyDefinition.ReadAssembly(assemblyFile);
-				return ((EmbeddedResource)asm.Modules.SelectMany(m => m.Resources).Single(r => r.Name == name)).GetResourceStream();
+				var module = ModuleDefinition.ReadModule(assemblyFile);
+				return ((EmbeddedResource)module.Resources.Single(r => r.Name == name)).GetResourceStream();
 			}
 		}
 		#endregion

--- a/ICSharpCode.NRefactory.Cecil/CecilLoader.cs
+++ b/ICSharpCode.NRefactory.Cecil/CecilLoader.cs
@@ -19,6 +19,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -163,6 +164,19 @@ namespace ICSharpCode.NRefactory.TypeSystem
 			moduleAttributes = interningProvider.InternList(moduleAttributes);
 			
 			this.currentAssembly = new CecilUnresolvedAssembly(assemblyDefinition != null ? assemblyDefinition.Name.FullName : moduleDefinition.Name, this.DocumentationProvider);
+
+			foreach (var res in moduleDefinition.Resources) {
+				switch (res.ResourceType) {
+					case ResourceType.Embedded:
+						currentAssembly.Resources.Add(new CecilEmbeddedResource(res.Name, moduleDefinition.FullyQualifiedName, res.IsPublic));
+						break;
+					case ResourceType.Linked:
+						currentAssembly.Resources.Add(new LinkedResource(res.Name, ((Mono.Cecil.LinkedResource)res).File, Path.GetDirectoryName(moduleDefinition.FullyQualifiedName), res.IsPublic));
+						break;
+					// There is also ResourceType.AssemblyLinked, but we don't support that (at least for now)
+				}
+			}
+
 			currentAssembly.Location = moduleDefinition.FullyQualifiedName;
 			currentAssembly.AssemblyAttributes.AddRange(assemblyAttributes);
 			currentAssembly.ModuleAttributes.AddRange(assemblyAttributes);
@@ -273,6 +287,32 @@ namespace ICSharpCode.NRefactory.TypeSystem
 					return documentationProvider.GetDocumentation(entity);
 				else
 					return null;
+			}
+		}
+
+		[Serializable, FastSerializerVersion(cecilLoaderVersion)]
+		sealed class CecilEmbeddedResource : IAssemblyResource {
+			private string name;
+			private string assemblyFile;
+			private bool isPublic;
+
+			public CecilEmbeddedResource(string name, string assemblyFile, bool isPublic) {
+				this.name = name;
+				this.assemblyFile = assemblyFile;
+				this.isPublic = isPublic;
+			}
+
+			public string Name { get { return name; } }
+
+			public AssemblyResourceType Type { get { return AssemblyResourceType.Embedded; } }
+
+			public string LinkedFileName { get { return null; } }
+
+			public bool IsPublic { get { return isPublic; } }
+
+			public Stream GetResourceStream() {
+				var asm = AssemblyDefinition.ReadAssembly(assemblyFile);
+				return ((EmbeddedResource)asm.Modules.SelectMany(m => m.Resources).Single(r => r.Name == name)).GetResourceStream();
 			}
 		}
 		#endregion

--- a/ICSharpCode.NRefactory.Tests/CSharp/Parser/TypeSystemConvertVisitorTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/Parser/TypeSystemConvertVisitorTests.cs
@@ -31,6 +31,31 @@ namespace ICSharpCode.NRefactory.CSharp.Parser
 	[TestFixture]
 	public class TypeSystemConvertVisitorTests : TypeSystemTests
 	{
+		[Serializable]
+		class EmbeddedResource : IAssemblyResource {
+			private readonly string name;
+			private readonly string filepath;
+			private readonly bool isPublic;
+
+			public string Name { get { return name; } }
+
+			public string LinkedFileName { get { return null; } }
+
+			public AssemblyResourceType Type { get { return AssemblyResourceType.Embedded; } }
+
+			public bool IsPublic { get { return isPublic; } }
+
+			public EmbeddedResource(string name, string filepath, bool isPublic) {
+				this.name = name;
+				this.filepath = filepath;
+				this.isPublic = isPublic;
+			}
+
+			public Stream GetResourceStream() {
+				return File.Open(filepath, FileMode.Open, FileAccess.Read);
+			}
+		}
+
 		[TestFixtureSetUp]
 		public void FixtureSetUp()
 		{
@@ -45,9 +70,9 @@ namespace ICSharpCode.NRefactory.CSharp.Parser
 					CecilLoaderTests.Mscorlib
 				})
 				.SetAssemblyName(typeof(TypeSystemTests).Assembly.GetName().Name)
-				.AddEmbeddedResource("ICSharpCode.NRefactory.TypeSystem.EmbeddedResource.txt", Path.Combine("TypeSystem", "EmbeddedResource.txt"), isPublic: true)
-				.AddEmbeddedResource("ICSharpCode.NRefactory.TypeSystem.PrivateEmbeddedResource.txt", Path.Combine("TypeSystem", "PrivateEmbeddedResource.txt"), isPublic: false)
-				.AddLinkedResource("ICSharpCode.NRefactory.TypeSystem.LinkedResource.txt", Path.Combine(Path.GetDirectoryName(typeof(TypeSystemConvertVisitorTests).Assembly.Location), "LinkedResource.txt"), isPublic: true);
+				.AddResources(new EmbeddedResource("ICSharpCode.NRefactory.TypeSystem.EmbeddedResource.txt", Path.Combine("TypeSystem", "EmbeddedResource.txt"), isPublic: true),
+				              new EmbeddedResource("ICSharpCode.NRefactory.TypeSystem.PrivateEmbeddedResource.txt", Path.Combine("TypeSystem", "PrivateEmbeddedResource.txt"), isPublic: false),
+				              new LinkedResource("ICSharpCode.NRefactory.TypeSystem.LinkedResource.txt", "LinkedResource.txt", Path.GetDirectoryName(typeof(TypeSystemConvertVisitorTests).Assembly.Location), isPublic: true));
 		}
 		
 		internal static IProjectContent ParseTestCase()

--- a/ICSharpCode.NRefactory.Tests/CSharp/Parser/TypeSystemConvertVisitorTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/Parser/TypeSystemConvertVisitorTests.cs
@@ -44,7 +44,10 @@ namespace ICSharpCode.NRefactory.CSharp.Parser
 				.AddAssemblyReferences(new[] {
 					CecilLoaderTests.Mscorlib
 				})
-				.SetAssemblyName(typeof(TypeSystemTests).Assembly.GetName().Name);
+				.SetAssemblyName(typeof(TypeSystemTests).Assembly.GetName().Name)
+				.AddEmbeddedResource("ICSharpCode.NRefactory.TypeSystem.EmbeddedResource.txt", Path.Combine("TypeSystem", "EmbeddedResource.txt"), isPublic: true)
+				.AddEmbeddedResource("ICSharpCode.NRefactory.TypeSystem.PrivateEmbeddedResource.txt", Path.Combine("TypeSystem", "PrivateEmbeddedResource.txt"), isPublic: false)
+				.AddLinkedResource("ICSharpCode.NRefactory.TypeSystem.LinkedResource.txt", Path.Combine(Path.GetDirectoryName(typeof(TypeSystemConvertVisitorTests).Assembly.Location), "LinkedResource.txt"), isPublic: true);
 		}
 		
 		internal static IProjectContent ParseTestCase()

--- a/ICSharpCode.NRefactory.Tests/ICSharpCode.NRefactory.Tests.csproj
+++ b/ICSharpCode.NRefactory.Tests/ICSharpCode.NRefactory.Tests.csproj
@@ -542,6 +542,19 @@
       <Name>ICSharpCode.NRefactory.IKVM</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="TypeSystem\EmbeddedResource.txt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
+    <LinkResource Include="TypeSystem\LinkedResource.txt">
+      <LogicalName>ICSharpCode.NRefactory.TypeSystem.LinkedResource.txt</LogicalName>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </LinkResource>
+    <EmbeddedResource Include="TypeSystem\PrivateEmbeddedResource.txt">
+      <Access>private</Access>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </EmbeddedResource>
+  </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>
     <MonoDevelop>

--- a/ICSharpCode.NRefactory.Tests/TypeSystem/EmbeddedResource.txt
+++ b/ICSharpCode.NRefactory.Tests/TypeSystem/EmbeddedResource.txt
@@ -1,0 +1,1 @@
+﻿Hello world from embedded resource

--- a/ICSharpCode.NRefactory.Tests/TypeSystem/LinkedResource.txt
+++ b/ICSharpCode.NRefactory.Tests/TypeSystem/LinkedResource.txt
@@ -1,0 +1,1 @@
+﻿Hello world from linked resource

--- a/ICSharpCode.NRefactory.Tests/TypeSystem/PrivateEmbeddedResource.txt
+++ b/ICSharpCode.NRefactory.Tests/TypeSystem/PrivateEmbeddedResource.txt
@@ -1,0 +1,1 @@
+﻿Hello world from private resource

--- a/ICSharpCode.NRefactory.Tests/TypeSystem/TypeSystemTests.cs
+++ b/ICSharpCode.NRefactory.Tests/TypeSystem/TypeSystemTests.cs
@@ -17,9 +17,11 @@
 // DEALINGS IN THE SOFTWARE.
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
+using System.Text;
 
 using ICSharpCode.NRefactory.CSharp.Resolver;
 using ICSharpCode.NRefactory.Semantics;
@@ -1395,6 +1397,43 @@ namespace ICSharpCode.NRefactory.TypeSystem
 			Assert.AreEqual(inner2, ((TypeOfResolveResult)inner2TypeTestAttr.PositionalArguments[1]).ReferencedType);
 			var inner2MyAttr = attributedInner2.Attributes.Single(a => a.AttributeType.Name == "MyAttribute");
 			Assert.AreEqual(myAttribute2, inner2MyAttr.AttributeType);
+		}
+
+		[Test]
+		public void ResourcesCanBeLoaded()
+		{
+			var res = compilation.MainAssembly.Resources.SingleOrDefault(r => r.Name == "ICSharpCode.NRefactory.TypeSystem.EmbeddedResource.txt");
+			Assert.That(res, Is.Not.Null);
+			Assert.That(res.Type, Is.EqualTo(AssemblyResourceType.Embedded));
+			Assert.That(res.IsPublic, Is.True);
+			Assert.That(res.LinkedFileName, Is.Null);
+			using (var rdr = new StreamReader(res.GetResourceStream(), Encoding.UTF8)) {
+				Assert.That(rdr.ReadToEnd(), Is.EqualTo("Hello world from embedded resource"));
+			}
+
+			res = compilation.MainAssembly.Resources.SingleOrDefault(r => r.Name == "ICSharpCode.NRefactory.TypeSystem.PrivateEmbeddedResource.txt");
+			Assert.That(res, Is.Not.Null);
+			Assert.That(res.Type, Is.EqualTo(AssemblyResourceType.Embedded));
+			Assert.That(res.IsPublic, Is.False);
+			Assert.That(res.LinkedFileName, Is.Null);
+			using (var rdr = new StreamReader(res.GetResourceStream(), Encoding.UTF8)) {
+				Assert.That(rdr.ReadToEnd(), Is.EqualTo("Hello world from private resource"));
+			}
+
+			res = compilation.MainAssembly.Resources.SingleOrDefault(r => r.Name == "ICSharpCode.NRefactory.TypeSystem.LinkedResource.txt");
+			Assert.That(res, Is.Not.Null);
+			Assert.That(res.Type, Is.EqualTo(AssemblyResourceType.Linked));
+			Assert.That(res.IsPublic, Is.True);
+			Assert.That(res.LinkedFileName, Is.EqualTo("LinkedResource.txt"));
+			try {
+				using (var rdr = new StreamReader(res.GetResourceStream(), Encoding.UTF8)) {
+					Assert.That(rdr.ReadToEnd(), Is.EqualTo("Hello world from linked resource"));
+				}
+			}
+			catch (FileNotFoundException ex) {
+				// In case our test runner does not copy the linked resource file, assume that it can be read if it were in the correct place.
+				Assert.That(ex.FileName, Is.EqualTo(Path.Combine(Path.GetDirectoryName(typeof(BinaryLoaderTests).Assembly.Location), "LinkedResource.txt")));
+			}
 		}
 	}
 }

--- a/ICSharpCode.NRefactory/ICSharpCode.NRefactory.csproj
+++ b/ICSharpCode.NRefactory/ICSharpCode.NRefactory.csproj
@@ -146,12 +146,14 @@
     <Compile Include="TypeSystem\DefaultSolutionSnapshot.cs" />
     <Compile Include="TypeSystem\DomRegion.cs" />
     <Compile Include="TypeSystem\EntityType.cs" />
+    <Compile Include="TypeSystem\IAssemblyResource.cs" />
     <Compile Include="TypeSystem\Implementation\BlobReader.cs" />
     <Compile Include="TypeSystem\Implementation\DefaultVariable.cs" />
     <Compile Include="TypeSystem\Implementation\ResolvedAttributeBlob.cs" />
     <Compile Include="TypeSystem\Implementation\UnresolvedAttributeBlob.cs" />
     <Compile Include="TypeSystem\Implementation\UnresolvedSecurityDeclarationBlob.cs" />
     <Compile Include="TypeSystem\ISymbol.cs" />
+    <Compile Include="TypeSystem\LinkedResource.cs" />
     <Compile Include="TypeSystem\TypeParameterSubstitution.cs" />
     <Compile Include="TypeSystem\TypeSystemExtensions.cs" />
     <Compile Include="TypeSystem\FullTypeName.cs" />

--- a/ICSharpCode.NRefactory/TypeSystem/IAssembly.cs
+++ b/ICSharpCode.NRefactory/TypeSystem/IAssembly.cs
@@ -56,6 +56,11 @@ namespace ICSharpCode.NRefactory.TypeSystem
 		/// Gets all non-nested types in the assembly.
 		/// </summary>
 		IEnumerable<IUnresolvedTypeDefinition> TopLevelTypeDefinitions { get; }
+
+		/// <summary>
+		/// Returns a list of all resources in the assembly.
+		/// </summary>
+		IEnumerable<IAssemblyResource> Resources { get; }
 	}
 	
 	public interface IAssemblyReference
@@ -124,5 +129,10 @@ namespace ICSharpCode.NRefactory.TypeSystem
 		/// Gets all non-nested types in the assembly.
 		/// </summary>
 		IEnumerable<ITypeDefinition> TopLevelTypeDefinitions { get; }
+
+		/// <summary>
+		/// Returns a list of all resources in the assembly.
+		/// </summary>
+		IEnumerable<IAssemblyResource> Resources { get; }
 	}
 }

--- a/ICSharpCode.NRefactory/TypeSystem/IAssemblyResource.cs
+++ b/ICSharpCode.NRefactory/TypeSystem/IAssemblyResource.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace ICSharpCode.NRefactory.TypeSystem {
+	public enum AssemblyResourceType {
+		/// <summary>
+		/// The resource is an embedded resource (created by the /resource csc command line)
+		/// </summary>
+		Embedded,
+		/// <summary>
+		/// The resource is a linked resource (created by the /linkresource csc command line)
+		/// </summary>
+		Linked,
+	}
+
+	public interface IAssemblyResource {
+		/// <summary>
+		/// Name of the resource.
+		/// </summary>
+		string Name { get; }
+
+		/// <summary>
+		/// Whether the resource is embedded or linked.
+		/// </summary>
+		AssemblyResourceType Type { get; }
+
+		/// <summary>
+		/// Name of the resource file for a linked resource.
+		/// </summary>
+		string LinkedFileName { get; }
+
+		/// <summary>
+		/// Whether the resource is public (as opposed to private).
+		/// </summary>
+		bool IsPublic { get; }
+
+		/// <summary>
+		/// Get the resource data as a stream. This method might throw an IOException if the resource is a linked resource and the file is not available.
+		/// </summary>
+		/// <returns></returns>
+		Stream GetResourceStream();
+	}
+}

--- a/ICSharpCode.NRefactory/TypeSystem/IProjectContent.cs
+++ b/ICSharpCode.NRefactory/TypeSystem/IProjectContent.cs
@@ -157,13 +157,23 @@ namespace ICSharpCode.NRefactory.TypeSystem
 		IProjectContent SetCompilerSettings(object compilerSettings);
 
 		/// <summary>
-		/// Adds a linked resource to the project.
+		/// Add resources to this project content.
 		/// </summary>
-		IProjectContent AddLinkedResource(string name, string filename, bool isPublic = true);
+		IProjectContent AddResources(IEnumerable<IAssemblyResource> resources);
 
 		/// <summary>
-		/// Adds an embedded resource to the project.
+		/// Add resources to this project content.
 		/// </summary>
-		IProjectContent AddEmbeddedResource(string name, string filepath, bool isPublic = true);
+		IProjectContent AddResources(params IAssemblyResource[] resources);
+
+		/// <summary>
+		/// Remove resources from this project content.
+		/// </summary>
+		IProjectContent RemoveResources(IEnumerable<IAssemblyResource> resources);
+
+		/// <summary>
+		/// Add resources to this project.
+		/// </summary>
+		IProjectContent RemoveResources(params IAssemblyResource[] resources);
 	}
 }

--- a/ICSharpCode.NRefactory/TypeSystem/IProjectContent.cs
+++ b/ICSharpCode.NRefactory/TypeSystem/IProjectContent.cs
@@ -155,5 +155,15 @@ namespace ICSharpCode.NRefactory.TypeSystem
 		/// Using the incorrect type of settings object results in an <see cref="ArgumentException"/>.
 		/// </summary>
 		IProjectContent SetCompilerSettings(object compilerSettings);
+
+		/// <summary>
+		/// Adds a linked resource to the project.
+		/// </summary>
+		IProjectContent AddLinkedResource(string name, string filename, bool isPublic = true);
+
+		/// <summary>
+		/// Adds an embedded resource to the project.
+		/// </summary>
+		IProjectContent AddEmbeddedResource(string name, string filepath, bool isPublic = true);
 	}
 }

--- a/ICSharpCode.NRefactory/TypeSystem/Implementation/DefaultUnresolvedAssembly.cs
+++ b/ICSharpCode.NRefactory/TypeSystem/Implementation/DefaultUnresolvedAssembly.cs
@@ -39,6 +39,7 @@ namespace ICSharpCode.NRefactory.TypeSystem.Implementation
 		string fullAssemblyName;
 		IList<IUnresolvedAttribute> assemblyAttributes;
 		IList<IUnresolvedAttribute> moduleAttributes;
+		IList<IAssemblyResource> resources;
 		Dictionary<TopLevelTypeName, IUnresolvedTypeDefinition> typeDefinitions = new Dictionary<TopLevelTypeName, IUnresolvedTypeDefinition>(TopLevelTypeNameComparer.Ordinal);
 		Dictionary<TopLevelTypeName, ITypeReference> typeForwarders = new Dictionary<TopLevelTypeName, ITypeReference>(TopLevelTypeNameComparer.Ordinal);
 		
@@ -47,6 +48,7 @@ namespace ICSharpCode.NRefactory.TypeSystem.Implementation
 			base.FreezeInternal();
 			assemblyAttributes = FreezableHelper.FreezeListAndElements(assemblyAttributes);
 			moduleAttributes = FreezableHelper.FreezeListAndElements(moduleAttributes);
+			resources = FreezableHelper.FreezeList(resources);
 			foreach (var type in typeDefinitions.Values) {
 				FreezableHelper.Freeze(type);
 			}
@@ -65,6 +67,7 @@ namespace ICSharpCode.NRefactory.TypeSystem.Implementation
 			this.assemblyName = pos < 0 ? assemblyName : assemblyName.Substring(0, pos);
 			this.assemblyAttributes = new List<IUnresolvedAttribute>();
 			this.moduleAttributes = new List<IUnresolvedAttribute>();
+			this.resources = new List<IAssemblyResource>();
 		}
 		
 		/// <summary>
@@ -130,6 +133,14 @@ namespace ICSharpCode.NRefactory.TypeSystem.Implementation
 		
 		public IEnumerable<IUnresolvedTypeDefinition> TopLevelTypeDefinitions {
 			get { return typeDefinitions.Values; }
+		}
+
+		public IList<IAssemblyResource> Resources {
+			get { return resources; }
+		}
+
+		IEnumerable<IAssemblyResource> IUnresolvedAssembly.Resources {
+			get { return resources; }
 		}
 		
 		/// <summary>
@@ -371,6 +382,10 @@ namespace ICSharpCode.NRefactory.TypeSystem.Implementation
 				get {
 					return unresolvedAssembly.TopLevelTypeDefinitions.Select(t => GetTypeDefinition(t));
 				}
+			}
+
+			public IEnumerable<IAssemblyResource> Resources {
+				get { return unresolvedAssembly.Resources; }
 			}
 			
 			public override string ToString()

--- a/ICSharpCode.NRefactory/TypeSystem/LinkedResource.cs
+++ b/ICSharpCode.NRefactory/TypeSystem/LinkedResource.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.IO;
+
+namespace ICSharpCode.NRefactory.TypeSystem {
+	[Serializable]
+	public class LinkedResource : IAssemblyResource {
+		private string _name;
+		private string _filename;
+		private string _basepath;
+		private bool _isPublic;
+
+		public string Name { get { return _name; } }
+
+		public string LinkedFileName { get { return _filename; } }
+
+		public AssemblyResourceType Type { get { return AssemblyResourceType.Linked; } }
+
+		public bool IsPublic { get { return _isPublic; } }
+
+		public LinkedResource(string name, string filename, string basepath, bool isPublic) {
+			_name = name;
+			_filename = filename;
+			_basepath = basepath;
+			_isPublic = isPublic;
+		}
+
+		public Stream GetResourceStream() {
+			return File.Open(Path.Combine(_basepath, _filename), FileMode.Open, FileAccess.Read);
+		}
+	}
+}


### PR DESCRIPTION
This property contains all embedded (/resource csc command line option) and linked (/linkresource option) resources. There is also something known as an "asssembly-linked" resource, but this is not supported because my Google-fu has failed me in finding out what it actually is and how to create one.

As discussed in #133, no resource data is being kept in memory unless the `GetResourceStream` method is used.
