### PR TITLE
Report comparison of nullable type parameter as being lifted.

### DIFF
--- a/ICSharpCode.NRefactory.Tests/CSharp/Resolver/BinaryOperatorTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/Resolver/BinaryOperatorTests.cs
@@ -893,5 +893,19 @@ class C
 			Assert.IsTrue(c.IsUserDefined);
 			Assert.AreEqual("E", c.Method.ReturnType.ReflectionName);
 		}
+
+		[Test]
+		public void EqualsForNullableTypeParameter() {
+			string program = @"using System;
+class C {
+	public void Test<T>(T? t) where T : struct {
+		bool b = $t == null$;
+	}
+}";
+			var rr = Resolve<OperatorResolveResult>(program);
+			Assert.AreEqual("System.Boolean", rr.Type.ReflectionName);
+			Assert.IsFalse(rr.IsError);
+			Assert.IsTrue(rr.IsLiftedOperator);
+		}
 	}
 }


### PR DESCRIPTION
This was already the case for nullable types where the underlying type was not a type parameter (eg. int?)
