### PR TITLE
NullValueAnalysis: Register result of default() expressions.

### DIFF
--- a/ICSharpCode.NRefactory.CSharp.Refactoring/CodeIssues/Uncategorized/UseOfMemberOfNullReference.cs
+++ b/ICSharpCode.NRefactory.CSharp.Refactoring/CodeIssues/Uncategorized/UseOfMemberOfNullReference.cs
@@ -59,7 +59,7 @@ namespace ICSharpCode.NRefactory.CSharp.Refactoring
 			public override void VisitMemberReferenceExpression(MemberReferenceExpression memberReferenceExpression)
 			{
 				IMember member = GetMember(memberReferenceExpression);
-				if (member == null || member.IsStatic) {
+				if (member == null || member.IsStatic || member.FullName == "System.Nullable.HasValue") {
 					base.VisitMemberReferenceExpression(memberReferenceExpression);
 					return;
 				}
@@ -69,8 +69,6 @@ namespace ICSharpCode.NRefactory.CSharp.Refactoring
 
 				var nullStatus = analysis.GetExpressionResult(memberReferenceExpression.Target);
 				if (ProblematicNullStates.Contains(nullStatus)) {
-					//Depending on how reliable the null analysis turns out to be, we may also want to include PotentiallyNull here
-
 					AddIssue(memberReferenceExpression,
 					         ctx.TranslateString("Using member of null value will cause a NullReferenceException"));
 				}

--- a/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/UseOfMemberOfNullReferenceTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/UseOfMemberOfNullReferenceTests.cs
@@ -39,7 +39,7 @@ namespace ICSharpCode.NRefactory.CSharp.CodeIssues
 			string input = @"
 class TestClass
 {
-	void TestMethod() {
+	int TestMethod() {
 		string x = null;
 		return x.Length;
 	}
@@ -53,9 +53,23 @@ class TestClass
 			string input = @"
 class TestClass
 {
-	void TestMethod() {
+	int TestMethod() {
 		string x = """";
 		return x.Length;
+	}
+}";
+			TestWrongContext<UseOfMemberOfNullReference> (input);
+		}
+
+		[Test]
+		public void TestDisabledForHasValue ()
+		{
+			string input = @"
+class TestClass
+{
+	bool TestMethod() {
+		int? x = null;
+		return x.HasValue;
 	}
 }";
 			TestWrongContext<UseOfMemberOfNullReference> (input);
@@ -70,7 +84,7 @@ static class X {
 }
 class TestClass
 {
-	void TestMethod() {
+	object TestMethod() {
 		string x = null;
 		return x.Clone();
 	}
@@ -90,7 +104,7 @@ class TestClass
 {
 	void TestMethod() {
 		string x = """";
-		return x.Foo();
+		x.Foo();
 	}
 }";
 			TestWrongContext<UseOfMemberOfNullReference> (input);
@@ -180,43 +194,40 @@ class TestClass
 			Test<UseOfMemberOfNullReference> (input, 1);
 		}
 
-		[Ignore("fixme")]
 		[Test]
 		public void TestNullExpression ()
 		{
 			string input = @"
 class TestClass
 {
-	void TestMethod() {
-		return (null).Length;
+	int TestMethod() {
+		return default(string).Length;
 	}
 }";
 			Test<UseOfMemberOfNullReference> (input, 1);
 		}
 
-		[Ignore("fixme")]
 		[Test]
 		public void TestNullExpressionCase2 ()
 		{
 			string input = @"
 class TestClass
 {
-	void TestMethod() {
-		return (null ?? null).Length;
+	int TestMethod() {
+		return (default(string) ?? default(string)).Length;
 	}
 }";
 			Test<UseOfMemberOfNullReference> (input, 1);
 		}
 
-		[Ignore("fixme")]
 		[Test]
 		public void TestNullExpressionCase3 ()
 		{
 			string input = @"
 class TestClass
 {
-	void TestMethod() {
-		return (1 == 1 ? null : "").Length;
+	int TestMethod() {
+		return (1 == 1 ? default(string) : """").Length;
 	}
 }";
 			Test<UseOfMemberOfNullReference> (input, 1);


### PR DESCRIPTION
NullValueAnalysis: Register result of default() expressions.
Detect constant conditions in conditional expressions, such as 1 == 1 ? Foo : Bar
UseOfMemberOfNullReference: Exclude Nullable.HasValue member.
Enabled some ignored unit tests.
