### PR TITLE
Improved accuracy of null analysis

### DIFF
--- a/ICSharpCode.NRefactory.Tests/CSharp/Analysis/NullValueAnalysisTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/Analysis/NullValueAnalysisTests.cs
@@ -355,6 +355,31 @@ namespace ICSharpCode.NRefactory.CSharp.Analysis
 		}
 
 		[Test]
+		public void TestVariableVisitsCount()
+		{
+			var parser = new CSharpParser();
+			var tree = parser.Parse(@"
+class TestClass
+{
+	void TestMethod()
+	{
+		string s = null;
+		while (s == null) {
+			string s2 = null;
+		}
+	}
+}
+", "test.cs");
+			Assert.AreEqual(0, tree.Errors.Count);
+			
+			var method = tree.Descendants.OfType<MethodDeclaration>().Single();
+			var analysis = CreateNullValueAnalysis(tree, method);
+
+			Assert.AreEqual(8, analysis.NodeVisits);
+		}
+
+
+		[Test]
 		public void TestInvocation()
 		{
 			var parser = new CSharpParser();


### PR DESCRIPTION
When leaving a block, remove variables declared in that block.
This improves the accuracy of GetVariableStateBefore/AfterStatement (correctly detects when a variable does not exist in a scope), makes the state have fewer variables in general (which should make it a bit faster since cloning states takes time) and prevents some unnecessary revising of nodes (which also improves speed).
