### PR TITLE
Implemented custom indentation levels.

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Formatter/Indent.cs
+++ b/ICSharpCode.NRefactory.CSharp/Formatter/Indent.cs
@@ -98,6 +98,33 @@ namespace ICSharpCode.NRefactory.CSharp
 			Update();
 		}
 
+		public void PopIf(IndentType type)
+		{
+			if (Count > 0 && Peek() == type)
+			{
+				Pop();
+			}
+		}
+
+		public void PopWhile(IndentType type)
+		{
+			while (Count > 0 && Peek() == type)
+			{
+				Pop();
+			}
+		}
+
+		public bool PopTry()
+		{
+			if (Count > 0)
+			{
+				Pop();
+				return true;
+			}
+
+			return false;
+		}
+
 		public int Count {
 			get {
 				return indentStack.Count;
@@ -165,6 +192,30 @@ namespace ICSharpCode.NRefactory.CSharp
 			var result = new Indent(options);
 			foreach (var i in indentStack)
 					result.Push(i);
+			return result;
+		}
+
+		public static Indent ConvertFrom(string indentString, Indent correctIndent, TextEditorOptions options = null)
+		{
+			options = options ?? TextEditorOptions.Default;
+			var result = new Indent(options);
+
+			var indent = string.Concat(indentString.Where(c => c == ' ' || c == '\t'));
+			var indentTypes = new Stack<IndentType>(correctIndent.indentStack);
+
+			foreach (var _ in indent.TakeWhile(c => c == '\t'))
+			{
+				if (indentTypes.Count > 0)
+					result.Push(indentTypes.Pop());
+				else
+					result.Push(IndentType.Continuation);
+			}
+
+			result.ExtraSpaces = indent
+				.SkipWhile(c => c == '\t')
+				.TakeWhile(c => c == ' ')
+				.Count();
+
 			return result;
 		}
 	}

--- a/ICSharpCode.NRefactory.CSharp/IndentEngine/CSharpIndentEngine.cs
+++ b/ICSharpCode.NRefactory.CSharp/IndentEngine/CSharpIndentEngine.cs
@@ -183,6 +183,13 @@ namespace ICSharpCode.NRefactory.CSharp
 			}
 		}
 
+		/// <inheritdoc />
+		public bool EnableCustomIndentLevels
+		{
+			get;
+			set;
+		}
+
 		#endregion
 
 		#region Fields

--- a/ICSharpCode.NRefactory.CSharp/IndentEngine/CacheIndentEngine.cs
+++ b/ICSharpCode.NRefactory.CSharp/IndentEngine/CacheIndentEngine.cs
@@ -116,6 +116,13 @@ namespace ICSharpCode.NRefactory.CSharp
 		}
 
 		/// <inheritdoc />
+		public bool EnableCustomIndentLevels
+		{
+			get { return currentEngine.EnableCustomIndentLevels; }
+			set { currentEngine.EnableCustomIndentLevels = value; }
+		}
+
+		/// <inheritdoc />
 		public void Push(char ch)
 		{
 			currentEngine.Push(ch);
@@ -154,7 +161,7 @@ namespace ICSharpCode.NRefactory.CSharp
 
 		/// <inheritdoc />
 		/// <remarks>
-		///     If the <paramref name="offset"/> is negative, the engine will
+		///     If the <paramref name="position"/> is negative, the engine will
 		///     update to: document.TextLength + (offset % document.TextLength+1)
 		///     Otherwise it will update to: offset % document.TextLength+1
 		/// </remarks>

--- a/ICSharpCode.NRefactory.CSharp/IndentEngine/IDocumentIndentEngine.cs
+++ b/ICSharpCode.NRefactory.CSharp/IndentEngine/IDocumentIndentEngine.cs
@@ -69,6 +69,12 @@ namespace ICSharpCode.NRefactory.CSharp
 		TextLocation Location { get; }
 
 		/// <summary>
+		///     If this is true, the engine should try to adjust its indent 
+		///     levels to manual user's corrections, even if they are wrong.
+		/// </summary>
+		bool EnableCustomIndentLevels { get; set; }
+
+		/// <summary>
 		///     Pushes a new char into the engine which calculates the new
 		///     indentation levels.
 		/// </summary>

--- a/ICSharpCode.NRefactory.CSharp/IndentEngine/NullIStateMachineIndentEngine.cs
+++ b/ICSharpCode.NRefactory.CSharp/IndentEngine/NullIStateMachineIndentEngine.cs
@@ -194,6 +194,14 @@ namespace ICSharpCode.NRefactory.CSharp
 				return TextLocation.Empty;
 			}
 		}
+
+		/// <inheritdoc />
+		public bool EnableCustomIndentLevels
+		{
+			get { return false; }
+			set { }
+		}
+
 		#endregion
 
 		#region ICloneable implementation

--- a/ICSharpCode.NRefactory.CSharp/IndentEngine/TextPasteIndentEngine.cs
+++ b/ICSharpCode.NRefactory.CSharp/IndentEngine/TextPasteIndentEngine.cs
@@ -65,11 +65,16 @@ namespace ICSharpCode.NRefactory.CSharp
 		/// <param name="textEditorOptions">
 		///    Text editor options for indentation.
 		/// </param>
+		/// <param name="formattingOptions">
+		///     C# formatting options.
+		/// </param>
 		public TextPasteIndentEngine(IStateMachineIndentEngine decoratedEngine, TextEditorOptions textEditorOptions, CSharpFormattingOptions formattingOptions)
 		{
 			this.engine = decoratedEngine;
 			this.textEditorOptions = textEditorOptions;
 			this.formattingOptions = formattingOptions;
+
+			this.engine.EnableCustomIndentLevels = false;
 		}
 
 		#endregion
@@ -201,6 +206,12 @@ namespace ICSharpCode.NRefactory.CSharp
 			get { return engine.Location; }
 		}
 
+		/// <inheritdoc />
+		public bool EnableCustomIndentLevels {
+			get { return engine.EnableCustomIndentLevels; }
+			set { engine.EnableCustomIndentLevels = value; }
+		}
+		
 		/// <inheritdoc />
 		public void Push(char ch)
 		{

--- a/ICSharpCode.NRefactory.Tests/IndentationTests/BlockTest.cs
+++ b/ICSharpCode.NRefactory.Tests/IndentationTests/BlockTest.cs
@@ -362,8 +362,8 @@ class Foo {
 	void Test ()
 	{
 		Foo(a, b, bar(c, d[T,  // T
-							G], // G
-						e), $    // e
+		                   G], // G
+		              e), $    // e
 			f);");
 			Assert.AreEqual("\t\t              ", indent.ThisLineIndent);
 			Assert.AreEqual("\t\t    ", indent.NextLineIndent);
@@ -519,7 +519,7 @@ class Foo {
 	{ 
 		if (true)
 			if (true)
-				;
+			{ }
 			else $ ", fmt);
 			Assert.AreEqual("\t\t\t", indent.ThisLineIndent);
 			Assert.AreEqual("\t\t\t\t", indent.NextLineIndent);
@@ -702,7 +702,6 @@ class Foo {
 			Assert.AreEqual("\t\t", indent.NextLineIndent);
 		}
 
-		[Ignore("Fixme")]
 		[Test]
 		public void TestBrackets_CustomIndent()
 		{
@@ -713,6 +712,7 @@ class Foo {
 	void Test ()
 	{
 		// ...
+			if (true)
 			{
 				$ 
 			}", fmt);
@@ -720,7 +720,6 @@ class Foo {
 			Assert.AreEqual("\t\t\t\t", indent.NextLineIndent);
 		}
 
-		[Ignore("Fixme")]
 		[Test]
 		public void TestBrackets_CustomIndent2()
 		{
@@ -730,11 +729,80 @@ class Foo {
 class Foo {
 	void Test ()
 	{
+				if (true)
 				{
 					// ...
 				} $ ", fmt);
 			Assert.AreEqual("\t\t\t\t", indent.ThisLineIndent);
 			Assert.AreEqual("\t\t", indent.NextLineIndent);
+		}
+
+		[Test]
+		public void TestBrackets_CustomIndent3()
+		{
+			CSharpFormattingOptions fmt = FormattingOptionsFactory.CreateMono();
+			fmt.AlignEmbeddedIfStatements = false;
+			var indent = Helper.CreateEngine(@"
+class Foo {
+	void Test ()
+	{
+		using (this)
+					if (true)
+					{ } $ ", fmt);
+			Assert.AreEqual("\t\t\t\t\t", indent.ThisLineIndent);
+			Assert.AreEqual("\t\t", indent.NextLineIndent);
+		}
+
+		[Test]
+		public void TestBrackets_CustomIndent4()
+		{
+			CSharpFormattingOptions fmt = FormattingOptionsFactory.CreateMono();
+			fmt.AlignEmbeddedIfStatements = false;
+			var indent = Helper.CreateEngine(@"
+class Foo {
+	void Test ()
+	{
+			using (this)
+			{
+					if (true)
+					{ } $ 
+			}", fmt);
+			Assert.AreEqual("\t\t\t\t\t", indent.ThisLineIndent);
+			Assert.AreEqual("\t\t\t\t", indent.NextLineIndent);
+		}
+
+		[Test]
+		public void TestBrackets_CustomIndent5()
+		{
+			CSharpFormattingOptions fmt = FormattingOptionsFactory.CreateMono();
+			fmt.AlignEmbeddedIfStatements = false;
+			var indent = Helper.CreateEngine(@"
+class Foo {
+	void Test ()
+	{
+		using (this)
+if (true)
+{ } $ ", fmt);
+			Assert.AreEqual("", indent.ThisLineIndent);
+			Assert.AreEqual("\t\t", indent.NextLineIndent);
+		}
+
+		[Test]
+		public void TestBrackets_CustomIndent6()
+		{
+			CSharpFormattingOptions fmt = FormattingOptionsFactory.CreateMono();
+			fmt.AlignEmbeddedIfStatements = false;
+			var indent = Helper.CreateEngine(@"
+class Foo {
+	void Test ()
+	{
+		using (this)
+			if (true)
+	{
+				$	
+	}", fmt);
+			Assert.AreEqual("\t\t\t\t", indent.ThisLineIndent);
+			Assert.AreEqual("\t\t\t\t", indent.NextLineIndent);
 		}
 
 		[Test]

--- a/ICSharpCode.NRefactory.Tests/IndentationTests/Helper.cs
+++ b/ICSharpCode.NRefactory.Tests/IndentationTests/Helper.cs
@@ -61,7 +61,7 @@ namespace ICSharpCode.NRefactory.IndentationTests
 			var document = new ReadOnlyDocument(sb.ToString());
 			var options = new TextEditorOptions();
 
-			var result = new CacheIndentEngine(new CSharpIndentEngine(document, options, policy));
+			var result = new CacheIndentEngine(new CSharpIndentEngine(document, options, policy) { EnableCustomIndentLevels = true });
 			result.Update(offset);
 			return result;
 		}
@@ -75,8 +75,8 @@ namespace ICSharpCode.NRefactory.IndentationTests
 				var document = new ReadOnlyDocument(code);
 				policy = policy ?? FormattingOptionsFactory.CreateMono();
 				options = options ?? new TextEditorOptions { IndentBlankLines = false };
-				
-				var engine = new CacheIndentEngine(new CSharpIndentEngine(document, options, policy));
+
+				var engine = new CacheIndentEngine(new CSharpIndentEngine(document, options, policy) { EnableCustomIndentLevels = true });
 				Random rnd = new Random();
 
 				for (int i = 0; i < count; i++) {
@@ -107,7 +107,7 @@ namespace ICSharpCode.NRefactory.IndentationTests
 				}
 				options = options ?? new TextEditorOptions { IndentBlankLines = false };
 
-				var engine = new CacheIndentEngine(new CSharpIndentEngine(document, options, policy));
+				var engine = new CacheIndentEngine(new CSharpIndentEngine(document, options, policy) { EnableCustomIndentLevels = true });
 				int errors = 0;
 
 				foreach (var ch in code)


### PR DESCRIPTION
This is an option, IDocumentIndentEngine.EnableCustomIndentLevels has to
be set to true in order to use this feature.
Custom indents work only on statements and bodies. Indentation level of
the block body should be equal to the indentation of the block's keyword
increased by its appropriate continuation.
