### PR TITLE
Fixed bug #14732

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Analysis/ReachabilityAnalysis.cs
+++ b/ICSharpCode.NRefactory.CSharp/Analysis/ReachabilityAnalysis.cs
@@ -125,6 +125,14 @@ namespace ICSharpCode.NRefactory.CSharp.Analysis
 				return conditionalExpression.FalseExpression.AcceptVisitor(this);
 			}
 
+			public override bool VisitBinaryOperatorExpression(BinaryOperatorExpression binaryOperatorExpression)
+			{
+				if (binaryOperatorExpression.Operator == BinaryOperatorType.NullCoalescing) {
+					return binaryOperatorExpression.Left.AcceptVisitor(this);
+				}
+				return base.VisitBinaryOperatorExpression(binaryOperatorExpression);
+			}
+
 			public override bool VisitIfElseStatement(IfElseStatement ifElseStatement)
 			{
 				if (ifElseStatement.Condition.AcceptVisitor(this))
@@ -136,6 +144,21 @@ namespace ICSharpCode.NRefactory.CSharp.Analysis
 				//No need to worry about null ast nodes, since AcceptVisitor will just
 				//return false in those cases
 				return ifElseStatement.FalseStatement.AcceptVisitor(this);
+			}
+
+			public override bool VisitForeachStatement(ForeachStatement foreachStatement)
+			{
+				//Even if the body is always recursive, the function may stop if the collection
+				// is empty.
+				return foreachStatement.InExpression.AcceptVisitor(this);
+			}
+
+			public override bool VisitForStatement(ForStatement forStatement)
+			{
+				if (forStatement.Initializers.Any(initializer => initializer.AcceptVisitor(this)))
+					return true;
+
+				return forStatement.Condition.AcceptVisitor(this);
 			}
 
 			public override bool VisitSwitchStatement(SwitchStatement switchStatement)

--- a/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/FunctionNeverReturnsIssueTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/FunctionNeverReturnsIssueTests.cs
@@ -438,5 +438,56 @@ class TestClass
 }";
 			TestWrongContext<FunctionNeverReturnsIssue> (input);
 		}
+
+		[Test]
+		public void TestForeach ()
+		{
+			//https://bugzilla.xamarin.com/show_bug.cgi?id=14732
+			var input = @"
+using System.Linq;
+class TestClass
+{
+	void TestMethod()
+	{
+		foreach (var x in new int[0])
+			TestMethod();
+	}
+}";
+			TestWrongContext<FunctionNeverReturnsIssue> (input);
+		}
+
+		[Test]
+		public void TestNoExecutionFor ()
+		{
+			var input = @"
+using System.Linq;
+class TestClass
+{
+	void TestMethod()
+	{
+		for (int i = 0; i < 0; ++i)
+			TestMethod ();
+	}
+}";
+			TestWrongContext<FunctionNeverReturnsIssue> (input);
+		}
+
+		[Test]
+		public void TestNullCoalescing ()
+		{
+			//https://bugzilla.xamarin.com/show_bug.cgi?id=14732
+			var input = @"
+using System.Linq;
+class TestClass
+{
+	TestClass parent;
+	int? value;
+	int TestMethod()
+	{
+		return value ?? parent.TestMethod();
+	}
+}";
+			TestWrongContext<FunctionNeverReturnsIssue> (input);
+		}
 	}
 }


### PR DESCRIPTION
https://bugzilla.xamarin.com/show_bug.cgi?id=14732

`CopyDirectory` in main/src/core/MonoDevelop.Core/MonoDevelop.Core.FileSystem/DefaultFileSystemExtension.cs
The recursion detector assumed statements in foreach loops were always executed at least once.

`State.RootState` in main/src/addins/MonoDevelop.XmlEditor/MonoDevelop.Xml.StateEngine/State.cs
The recursion detector incorrectly considered `non_recursive ?? recursive` to be recursive.

Also fixed for statements (which had a problem similar to foreach statements)
