### PR TITLE
Fixed two bugs in LinqFluentToQueryTests.

### DIFF
--- a/ICSharpCode.NRefactory.Tests/CSharp/CodeActions/LinqFluentToQueryTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/CodeActions/LinqFluentToQueryTests.cs
@@ -137,6 +137,33 @@ class TestClass
 		}
 
 		[Test]
+		public void TestLet2()
+		{
+			Test<LinqFluentToQueryAction>(@"
+using System.Linq;
+
+class TestClass
+{
+	void TestMethod ()
+	{
+		var x = new int[0].Select (w => new { two = w * 2, w }).$Select (_ => _.two);
+	}
+}", @"
+using System.Linq;
+
+class TestClass
+{
+	void TestMethod ()
+	{
+		var x = 
+			from w in new int[0]
+	let two = w * 2
+	select two;
+	}
+}");
+		}
+
+		[Test]
 		public void TestLongLetChain()
 		{
 			Test<LinqFluentToQueryAction>(@"
@@ -149,6 +176,40 @@ class TestClass
 		var x = new int[0].Select (w => new { w, two = w * 2 })
 			.Select (h => new { h, three = h.w * 3 })
 			.Select (k => new { k, four = k.h.w * 4 })
+			.$Select (_ => _.k.h.w + _.k.h.two + _.k.three + _.four)
+			.Select (sum => sum * 2);
+	}
+}", @"
+using System.Linq;
+
+class TestClass
+{
+	void TestMethod ()
+	{
+		var x = 
+			from w in new int[0]
+	let two = w * 2
+	let three = w * 3
+	let four = w * 4
+	select w + two + three + four into sum
+	select sum * 2;
+	}
+}");
+		}
+
+		[Test]
+		public void TestLongLetChain2()
+		{
+			Test<LinqFluentToQueryAction>(@"
+using System.Linq;
+
+class TestClass
+{
+	void TestMethod ()
+	{
+		var x = new int[0].Select (w => new { two = w * 2, w })
+			.Select (h => new { three = h.w * 3, h })
+			.Select (k => new { four = k.h.w * 4, k })
 			.$Select (_ => _.k.h.w + _.k.h.two + _.k.three + _.four)
 			.Select (sum => sum * 2);
 	}
@@ -193,6 +254,68 @@ class TestClass
 			from elem1 in new int[0]
 	from elem2 in new int[0]
 	select elem1 + elem2;
+	}
+}");
+		}
+
+		[Test]
+		public void TestSelectManyLet()
+		{
+			Test<LinqFluentToQueryAction>(@"
+using System.Linq;
+
+class TestClass
+{
+	void TestMethod ()
+	{
+		var x = new int[0].$SelectMany (elem => new int[0], (elem1, elem2) => new { elem1, elem2 }).Select(i => new { i, sum = i.elem1 + i.elem2 })
+			.Select(j => j.i.elem1 + j.i.elem2 + j.sum);
+	}
+}", @"
+using System.Linq;
+
+class TestClass
+{
+	void TestMethod ()
+	{
+		var x = 
+			from elem1 in new int[0]
+	from elem2 in new int[0]
+	let sum = elem1 + elem2
+	select elem1 + elem2 + sum;
+	}
+}");
+		}
+
+		[Test]
+		public void TestSelectManyLet2()
+		{
+			Test<LinqFluentToQueryAction>(@"
+using System.Linq;
+
+class TestClass
+{
+	void TestMethod ()
+	{
+		var x = new int[0].$SelectMany (elem => new int[0], (elem1, elem2) => new { elem1, elem2 = elem2 + 1 }).Select(i => new { i, sum = i.elem1 + i.elem2 })
+			.Select(j => j.i.elem1 + j.i.elem2 + j.sum);
+	}
+}", @"
+using System.Linq;
+
+class TestClass
+{
+	void TestMethod ()
+	{
+		var x = 
+			from elem1 in new int[0]
+	from elem2 in new int[0]
+	select new {
+		elem1,
+		elem2 = elem2 + 1
+	} into i
+	let sum = i.elem1 + i.elem2
+	select i.elem1 + i.elem2 + sum;
 	}
 }");
 		}


### PR DESCRIPTION
Fixed a couple of bugs I ran into.

1) Recognized h => new { h, i = h } but not h => new { i = h, h }
2) Generated let foo = foo for some queries.
