### PR TITLE
Fixed 'Bug 10858 - Extract Method should use return, not out'

### DIFF
--- a/ICSharpCode.NRefactory.Tests/CSharp/CodeActions/ExtractMethodTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/CodeActions/ExtractMethodTests.cs
@@ -212,15 +212,17 @@ namespace ICSharpCode.NRefactory.CSharp.CodeActions
 ", @"class TestClass
 {
 	int member;
-	void NewMethod (int i, ref int j, out int k)
+	int NewMethod (int i, ref int j)
 	{
+		int k;
 		j = i + j;
 		k = j + member;
+		return k;
 	}
 	void TestMethod ()
 	{
 		int i = 5, j = 10, k;
-		NewMethod (i, ref j, out k);
+		k = NewMethod (i, ref j);
 		Console.WriteLine (k + j);
 	}
 }
@@ -278,17 +280,19 @@ class TestClass
 }
 ", @"class TestClass
 {
-	static void NewMethod (out string ret, string x, int y)
+	static string NewMethod (string x, int y)
 	{
+		string ret;
 		string z = ret + y;
 		ret = x + z;
+		return ret;
 	}
 	void TestMethod ()
 	{
 		string ret;
 		string x;
 		int y;
-		NewMethod (out ret, x, y);
+		ret = NewMethod (x, y);
 	}
 }
 ");
@@ -516,7 +520,6 @@ class TestClass
 		/// Bug 10858 - Extract Method should use return, not out
 		/// </summary>
 		[Test]
-		[Ignore ("FIXME")]
 		public void TestBug10858 ()
 		{
 			Test<ExtractMethodAction> (@"class TestClass
@@ -536,7 +539,7 @@ class TestClass
 	{
 		int j;
 		j = i + k;
-		return j
+		return j;
 	}
 	public static void TestMethod ()
 	{


### PR DESCRIPTION
Hi,

This is a proposition to fix the Bug 10858 - Extract Method should use return, not out.
The method extracted uses returns when there is only one argument with the out modifier.
I checked that the corresponding unit tests passed.

Best regards,
