### PR TITLE
Fix issue #331: Resolver shouldn't use private extension methods

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Resolver/CSharpResolver.cs
+++ b/ICSharpCode.NRefactory.CSharp/Resolver/CSharpResolver.cs
@@ -1833,11 +1833,12 @@ namespace ICSharpCode.NRefactory.CSharp.Resolver
 		/// </remarks>
 		public List<List<IMethod>> GetExtensionMethods(IType targetType, string name = null, IList<IType> typeArguments = null, bool substituteInferredTypes = false)
 		{
+			var lookup = CreateMemberLookup();
 			List<List<IMethod>> extensionMethodGroups = new List<List<IMethod>>();
 			foreach (var inputGroup in GetAllExtensionMethods()) {
 				List<IMethod> outputGroup = new List<IMethod>();
 				foreach (var method in inputGroup) {
-					if (name != null && method.Name != name)
+					if ((name != null && method.Name != name) || !lookup.IsAccessible(method, false))
 						continue;
 					
 					IType[] inferredTypes;

--- a/ICSharpCode.NRefactory.Tests/CSharp/Resolver/InvocationTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/Resolver/InvocationTests.cs
@@ -832,5 +832,53 @@ class Program
 			var rr = Resolve<CSharpInvocationResolveResult>(program);
 			Assert.IsFalse(rr.IsError);
 		}
+
+		[Test]
+		public void PrivateExtensionMethodIsNotUsableFromOtherClass() {
+			string program = @"
+using System.Collections.Generic;
+namespace Foo {
+	public static class FooExtensions {
+		static T Extension<T>(this object value) { return default(T); }
+	}
+}
+namespace Bar {
+	public static class BarExtensions {
+		public static IEnumerable<T> Extension<T>(this object value) { return new T[0]; }
+	}
+}
+
+namespace Bazz {
+	using Foo;
+	using Bar;
+
+	public class Client {
+		public void Method() {
+			var x = $new object().Extension<int>()$;
+		}
+	}
+}";
+			var rr = Resolve<CSharpInvocationResolveResult>(program);
+			Assert.IsFalse(rr.IsError);
+			Assert.AreEqual(rr.Type.FullName, "System.Collections.Generic.IEnumerable");
+		}
+
+		[Test]
+		public void PrivateExtensionMethodIsUsableFromSameClass() {
+			string program = @"
+using System.Collections.Generic;
+namespace Foo {
+	public static class FooExtensions {
+		static T Extension<T>(this object value) { return default(T); }
+
+		static void Method() {
+			var x = $new object().Extension<int>()$;
+		}
+	}
+}";
+			var rr = Resolve<CSharpInvocationResolveResult>(program);
+			Assert.IsFalse(rr.IsError);
+			Assert.AreEqual(rr.Type.FullName, "System.Int32");
+		}
 	}
 }


### PR DESCRIPTION
I hope this is correct. At least it doesn't cause any tests to fail.
