### PR TITLE
Implemented RedundantNotNullAttributeInNonNullableTypeIssue

### DIFF
--- a/ICSharpCode.NRefactory.CSharp.Refactoring/CodeIssues/Uncategorized/RedundantNotNullAttributeInNonNullableTypeIssue.cs
+++ b/ICSharpCode.NRefactory.CSharp.Refactoring/CodeIssues/Uncategorized/RedundantNotNullAttributeInNonNullableTypeIssue.cs
@@ -1,0 +1,101 @@
+//
+// RedundantNotNullAttributeInNonNullableTypeIssue.cs
+//
+// Author:
+//      Luís Reis <luiscubal@gmail.com>
+// 
+// Copyright (c) 2013 Luís Reis
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+
+using System;
+using System.Linq;
+using ICSharpCode.NRefactory.Refactoring;
+using ICSharpCode.NRefactory.Semantics;
+using ICSharpCode.NRefactory.TypeSystem;
+
+namespace ICSharpCode.NRefactory.CSharp.Refactoring
+{
+	[IssueDescription("Use of NotNullAttribute in non-nullable type is redundant.",
+		Description = "Detects unnecessary usages of the NotNullAttribute.",
+		Category = IssueCategories.RedundanciesInDeclarations,
+		Severity = Severity.Warning)]
+	public class RedundantNotNullAttributeInNonNullableTypeIssue : GatherVisitorCodeIssueProvider
+	{
+		protected override IGatherVisitor CreateVisitor(BaseRefactoringContext context)
+		{
+			return new GatherVisitor(context);
+		}
+
+		class GatherVisitor : GatherVisitorBase<RedundantNotNullAttributeInNonNullableTypeIssue>
+		{
+			public GatherVisitor(BaseRefactoringContext context) : base(context)
+			{
+			}
+
+			public override void VisitBlockStatement(BlockStatement blockStatement)
+			{
+				// This is just here to prevent the visitor from unnecessarily visiting the children.
+			}
+
+			public override void VisitAttribute(Attribute attribute)
+			{
+				var attributeType = ctx.Resolve(attribute).Type;
+				if (attributeType.FullName == AnnotationNames.NotNullAttribute) {
+					if (IsAttributeRedundant(attribute)) {
+						AddIssue(new CodeIssue(attribute,
+							ctx.TranslateString("NotNullAttribute is not needed for non-nullable types"),
+							ctx.TranslateString("Remove redundant NotNullAttribute"),
+							script => script.RemoveAttribute(attribute)));
+					}
+				}
+			}
+
+			bool IsAttributeRedundant(Attribute attribute)
+			{
+				var section = attribute.GetParent<AttributeSection>();
+				var targetDeclaration = section.Parent;
+
+				if (targetDeclaration is FixedFieldDeclaration) {
+					//Fixed fields are never null
+					return true;
+				}
+
+				var fieldDeclaration = targetDeclaration as FieldDeclaration;
+				if (fieldDeclaration != null) {
+					return fieldDeclaration.Variables.All(variable => NullableType.IsNonNullableValueType(ctx.Resolve(variable).Type));
+				}
+
+				var resolveResult = ctx.Resolve(targetDeclaration);
+				var memberResolveResult = resolveResult as MemberResolveResult;
+				if (memberResolveResult != null) {
+					return NullableType.IsNonNullableValueType(memberResolveResult.Member.ReturnType);
+				}
+				var localResolveResult = resolveResult as LocalResolveResult;
+				if (localResolveResult != null) {
+					return NullableType.IsNonNullableValueType(localResolveResult.Type);
+				}
+
+				return false;
+			}
+		}
+	}
+}
+

--- a/ICSharpCode.NRefactory.CSharp.Refactoring/ICSharpCode.NRefactory.CSharp.Refactoring.csproj
+++ b/ICSharpCode.NRefactory.CSharp.Refactoring/ICSharpCode.NRefactory.CSharp.Refactoring.csproj
@@ -424,6 +424,7 @@
     <Compile Include="CodeIssues\TODO\PartOfBodyCanBeConvertedToQueryIssue.cs" />
     <Compile Include="CodeIssues\TODO\RedundantTypeArgumentsOfMethodIssue.cs" />
     <Compile Include="CodeIssues\Synced\PracticesAndImprovements\PossibleMistakenCallToGetTypeIssue.cs" />
+    <Compile Include="CodeIssues\Uncategorized\RedundantNotNullAttributeInNonNullableTypeIssue.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/ICSharpCode.NRefactory.CSharp/Analysis/AnnotationNames.cs
+++ b/ICSharpCode.NRefactory.CSharp/Analysis/AnnotationNames.cs
@@ -1,0 +1,48 @@
+// 
+// Annotations.cs
+//  
+// Author:
+//       Luís Reis <luiscubal@gmail.com>
+// 
+// Copyright (c) 2013 Luís Reis
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+
+namespace ICSharpCode.NRefactory.CSharp
+{
+	public static class AnnotationNames
+	{
+		//Used const instead of readonly to allow values to be used in switch cases.
+
+		public const string AssertionMethodAttribute = "JetBrains.Annotations.AssertionMethodAttribute";
+		public const string AssertionConditionAttribute = "JetBrains.Annotations.AssertionConditionAttribute";
+		public const string AssertionConditionTypeAttribute = "JetBrains.Annotations.AssertionConditionType";
+
+		public const string AssertionConditionTypeIsTrue = "JetBrains.Annotations.AssertionConditionType.IS_TRUE";
+		public const string AssertionConditionTypeIsFalse = "JetBrains.Annotations.AssertionConditionType.IS_FALSE";
+		public const string AssertionConditionTypeIsNull = "JetBrains.Annotations.AssertionConditionType.IS_NULL";
+		public const string AssertionConditionTypeIsNotNull = "JetBrains.Annotations.AssertionConditionType.IS_NOT_NULL";
+
+		public const string NotNullAttribute = "JetBrains.Annotations.NotNullAttribute";
+		public const string CanBeNullAttribute = "JetBrains.Annotations.CanBeNullAttribute";
+	}
+}
+

--- a/ICSharpCode.NRefactory.CSharp/Analysis/NullValueAnalysis.cs
+++ b/ICSharpCode.NRefactory.CSharp/Analysis/NullValueAnalysis.cs
@@ -1470,9 +1470,9 @@ namespace ICSharpCode.NRefactory.CSharp.Analysis
 
 				var method = methodResolveResult.Member as IMethod;
 				if (method != null) {
-					if (method.GetAttribute(new FullTypeName("JetBrains.Annotations.AssertionMethodAttribute")) != null) {
+					if (method.GetAttribute(new FullTypeName(AnnotationNames.AssertionMethodAttribute)) != null) {
 						var assertionParameters = method.Parameters.Select((parameter, index) => new { index, parameter })
-							.Select(parameter => new { parameter.index, parameter.parameter, attributes = parameter.parameter.Attributes.Where(attribute => attribute.AttributeType.FullName == "JetBrains.Annotations.AssertionConditionAttribute").ToList() })
+							.Select(parameter => new { parameter.index, parameter.parameter, attributes = parameter.parameter.Attributes.Where(attribute => attribute.AttributeType.FullName == AnnotationNames.AssertionConditionAttribute).ToList() })
 							.Where(parameter => parameter.attributes.Count() == 1)
 							.Select(parameter => new { parameter.index, parameter.parameter, attribute = parameter.attributes[0] })
 							.ToList();
@@ -1486,18 +1486,18 @@ namespace ICSharpCode.NRefactory.CSharp.Analysis
 
 							object intendedResult = true;
 							var positionalArgument = assertionParameter.attribute.PositionalArguments.FirstOrDefault() as MemberResolveResult;
-							if (positionalArgument != null && positionalArgument.Type.FullName == "JetBrains.Annotations.AssertionConditionType") {
+							if (positionalArgument != null && positionalArgument.Type.FullName == AnnotationNames.AssertionConditionTypeAttribute) {
 								switch (positionalArgument.Member.FullName) {
-									case "JetBrains.Annotations.AssertionConditionType.IS_TRUE":
+									case AnnotationNames.AssertionConditionTypeIsTrue:
 										intendedResult = true;
 										break;
-									case "JetBrains.Annotations.AssertionConditionType.IS_FALSE":
+									case AnnotationNames.AssertionConditionTypeIsFalse:
 										intendedResult = false;
 										break;
-									case "JetBrains.Annotations.AssertionConditionType.IS_NULL":
+									case AnnotationNames.AssertionConditionTypeIsNull:
 										intendedResult = null;
 										break;
-									case "JetBrains.Annotations.AssertionConditionType.IS_NOT_NULL":
+									case AnnotationNames.AssertionConditionTypeIsNotNull:
 										intendedResult = "<not-null>";
 										break;
 								}
@@ -1606,10 +1606,10 @@ namespace ICSharpCode.NRefactory.CSharp.Analysis
 
 			static NullValueStatus GetNullableStatus(Func<string, IAttribute> attributeGetter)
 			{
-				if (attributeGetter("JetBrains.Annotations.NotNullAttribute") != null) {
+				if (attributeGetter(AnnotationNames.NotNullAttribute) != null) {
 					return NullValueStatus.DefinitelyNotNull;
 				}
-				if (attributeGetter("JetBrains.Annotations.CanBeNullAttribute") != null) {
+				if (attributeGetter(AnnotationNames.CanBeNullAttribute) != null) {
 					return NullValueStatus.PotentiallyNull;
 				}
 				return NullValueStatus.Unknown;

--- a/ICSharpCode.NRefactory.CSharp/ICSharpCode.NRefactory.CSharp.csproj
+++ b/ICSharpCode.NRefactory.CSharp/ICSharpCode.NRefactory.CSharp.csproj
@@ -78,11 +78,11 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+      <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
+      <RequiredTargetFramework>4.0</RequiredTargetFramework>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -384,6 +384,7 @@
     <Compile Include="IndentEngine\NullIStateMachineIndentEngine.cs" />
     <Compile Include="Refactoring\CodeGenerationService.cs" />
     <Compile Include="Formatter\FormattingVisitor_Query.cs" />
+    <Compile Include="Analysis\AnnotationNames.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ICSharpCode.NRefactory\ICSharpCode.NRefactory.csproj">

--- a/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/RedundantNotNullAttributeInNonNullableTypeTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/RedundantNotNullAttributeInNonNullableTypeTests.cs
@@ -1,0 +1,220 @@
+// 
+// RedundantNotNullAttributeInNonNullableTypeTests.cs
+//
+// Author:
+//       Luís Reis <luiscubal@gmail.com>
+// 
+// Copyright (c) 2013 Luís Reis
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using NUnit.Framework;
+using ICSharpCode.NRefactory.CSharp.Refactoring;
+
+namespace ICSharpCode.NRefactory.CSharp.CodeIssues
+{
+	[TestFixture]
+	public class RedundantNotNullAttributeTests : InspectionActionTestBase
+	{
+		[Test]
+		public void TestValidReturn() {
+			TestWrongContext<RedundantNotNullAttributeInNonNullableTypeIssue>(@"namespace JetBrains.Annotations
+{
+	[System.AttributeUsage(System.AttributeTargets.Method)]
+	class NotNullAttribute : System.Attribute
+	{
+	}
+}
+class TestClass
+{
+	[JetBrains.Annotations.NotNull]
+	object NotNull() {
+		return 1;
+	}
+}");
+		}
+
+		[Test]
+		public void TestRedundantReturn() {
+			Test<RedundantNotNullAttributeInNonNullableTypeIssue>(@"namespace JetBrains.Annotations
+{
+	[System.AttributeUsage(System.AttributeTargets.Method)]
+	class NotNullAttribute : System.Attribute
+	{
+	}
+}
+class TestClass
+{
+	[JetBrains.Annotations.NotNull]
+	int NotNull() {
+		return 1;
+	}
+}", @"namespace JetBrains.Annotations
+{
+	[System.AttributeUsage(System.AttributeTargets.Method)]
+	class NotNullAttribute : System.Attribute
+	{
+	}
+}
+class TestClass
+{
+	int NotNull() {
+		return 1;
+	}
+}");
+		}
+
+		[Test]
+		public void TestValidField() {
+			TestWrongContext<RedundantNotNullAttributeInNonNullableTypeIssue>(@"namespace JetBrains.Annotations
+{
+	[System.AttributeUsage(System.AttributeTargets.Field)]
+	class NotNullAttribute : System.Attribute
+	{
+	}
+}
+class TestClass
+{
+	[JetBrains.Annotations.NotNull]
+	object NotNullField;
+}");
+		}
+
+		[Test]
+		public void TestValidNullable() {
+			TestWrongContext<RedundantNotNullAttributeInNonNullableTypeIssue>(@"namespace JetBrains.Annotations
+{
+	[System.AttributeUsage(System.AttributeTargets.Field)]
+	class NotNullAttribute : System.Attribute
+	{
+	}
+}
+class TestClass
+{
+	[JetBrains.Annotations.NotNull]
+	int? NotNullField;
+}");
+		}
+
+		[Test]
+		public void TestRedundantField() {
+			Test<RedundantNotNullAttributeInNonNullableTypeIssue>(@"namespace JetBrains.Annotations
+{
+	[System.AttributeUsage(System.AttributeTargets.Field)]
+	class NotNullAttribute : System.Attribute
+	{
+	}
+}
+class TestClass
+{
+	[JetBrains.Annotations.NotNull]
+	int NotNullField;
+}", @"namespace JetBrains.Annotations
+{
+	[System.AttributeUsage(System.AttributeTargets.Field)]
+	class NotNullAttribute : System.Attribute
+	{
+	}
+}
+class TestClass
+{
+	int NotNullField;
+}");
+		}
+
+		[Test]
+		public void TestRedundantFixedField() {
+			Test<RedundantNotNullAttributeInNonNullableTypeIssue>(@"namespace JetBrains.Annotations
+{
+	[System.AttributeUsage(System.AttributeTargets.Field)]
+	class NotNullAttribute : System.Attribute
+	{
+	}
+}
+unsafe struct TestClass
+{
+	[JetBrains.Annotations.NotNull]
+	fixed object NotNullField[1024];
+}", @"namespace JetBrains.Annotations
+{
+	[System.AttributeUsage(System.AttributeTargets.Field)]
+	class NotNullAttribute : System.Attribute
+	{
+	}
+}
+unsafe struct TestClass
+{
+	fixed object NotNullField[1024];
+}");
+		}
+
+		[Test]
+		public void TestRedundantProperty() {
+			Test<RedundantNotNullAttributeInNonNullableTypeIssue>(@"namespace JetBrains.Annotations
+{
+	[System.AttributeUsage(System.AttributeTargets.Property)]
+	class NotNullAttribute : System.Attribute
+	{
+	}
+}
+class TestClass
+{
+	[JetBrains.Annotations.NotNull]
+	int NotNullField { get; set; }
+}", @"namespace JetBrains.Annotations
+{
+	[System.AttributeUsage(System.AttributeTargets.Property)]
+	class NotNullAttribute : System.Attribute
+	{
+	}
+}
+class TestClass
+{
+	int NotNullField { get; set; }
+}");
+		}
+
+		[Test]
+		public void TestRedundantParameter() {
+			Test<RedundantNotNullAttributeInNonNullableTypeIssue>(@"namespace JetBrains.Annotations
+{
+	[System.AttributeUsage(System.AttributeTargets.Parameter)]
+	class NotNullAttribute : System.Attribute
+	{
+	}
+}
+class TestClass
+{
+	void Foo([JetBrains.Annotations.NotNull]int x) {}
+}", @"namespace JetBrains.Annotations
+{
+	[System.AttributeUsage(System.AttributeTargets.Parameter)]
+	class NotNullAttribute : System.Attribute
+	{
+	}
+}
+class TestClass
+{
+	void Foo(int x) {}
+}");
+		}
+	}
+}
+

--- a/ICSharpCode.NRefactory.Tests/ICSharpCode.NRefactory.Tests.csproj
+++ b/ICSharpCode.NRefactory.Tests/ICSharpCode.NRefactory.Tests.csproj
@@ -612,6 +612,7 @@
     <Compile Include="CSharp\CodeIssues\PartOfBodyCanBeConvertedToQueryIssueTests.cs" />
     <Compile Include="CSharp\CodeIssues\RedundantTypeArgumentsOfMethodIssueTests.cs" />
     <Compile Include="CSharp\CodeIssues\PossibleMistakenCallToGetTypeIssueTests.cs" />
+    <Compile Include="CSharp\CodeIssues\RedundantNotNullAttributeInNonNullableTypeTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\cecil\Mono.Cecil.csproj">


### PR DESCRIPTION
Detects when [NotNull] is applied to declarations with non-nullable types, which is redundant.
