### PR TITLE
Created unit test for Windows-only resolver bug.

### DIFF
--- a/ICSharpCode.NRefactory.Tests/CSharp/Resolver/LambdaTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/Resolver/LambdaTests.cs
@@ -77,6 +77,26 @@ class SomeClass<T> {
 			var lrr = Resolve<LocalResolveResult>(program);
 			Assert.AreEqual("System.String", lrr.Type.ReflectionName);
 		}
+
+		[Test]
+		public void LambdaTaskParameterTest()
+		{
+			string program = @"using System.Threading.Tasks;
+
+class TestClass {
+	public void TestMethod () {
+		Task<int> foo = null;
+		foo.ContinueWith($precedent => {
+			Console.WriteLine (precedent.IsFaulted);
+		}$);
+	}
+}";
+
+			var lambdaResolveResult = Resolve<LambdaResolveResult>(program);
+
+			//Precedent must be of type Task<int>, not just Task
+			Assert.IsTrue(lambdaResolveResult.Parameters[0].Type.IsParameterized);
+		}
 		
 		#region Lambda In Array Initializer
 		[Test]


### PR DESCRIPTION
Added an unit test for a resolver bug that happens only on Windows (see https://github.com/icsharpcode/NRefactory/issues/359).
Note that the resolver decides that precedent is of type `Task`, not `Task<int>` **but only on Windows**. On Ubuntu, it correctly guesses the type of the precedent task.
For extra weirdness, comment the `Console.WriteLine (precedent.IsFaulted);` line. Note that the bug will go away.

Disclaimer: I'm not 100% sure my Windows and Linux systems are running the same IKVM/Cecil versions.
