### PR TITLE
Fixing Constructor Initializer

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Formatter/CSharpFormattingOptions.cs
+++ b/ICSharpCode.NRefactory.CSharp/Formatter/CSharpFormattingOptions.cs
@@ -450,6 +450,16 @@ namespace ICSharpCode.NRefactory.CSharp
 			get;
 			set;
 		}
+
+		public NewLinePlacement NewLineBeforeConstructorInitializerColon {
+			get;
+			set;
+		}
+
+		public NewLinePlacement NewLineAfterConstructorInitializerColon {
+			get;
+			set;
+		}
 		
 		// indexer
 		public bool SpaceBeforeIndexerDeclarationBracket { // tested

--- a/ICSharpCode.NRefactory.CSharp/Formatter/FormattingOptionsFactory.cs
+++ b/ICSharpCode.NRefactory.CSharp/Formatter/FormattingOptionsFactory.cs
@@ -266,6 +266,8 @@ namespace ICSharpCode.NRefactory.CSharp
 				SpaceBeforeIndexerDeclarationBracket = false,
 				SpaceAfterMethodCallParameterComma = true,
 				SpaceAfterConstructorDeclarationParameterComma = true,
+				NewLineBeforeConstructorInitializerColon = NewLinePlacement.NewLine,
+				NewLineAfterConstructorInitializerColon = NewLinePlacement.SameLine,
 				
 				SpaceBeforeNewParentheses = false,
 				SpacesWithinNewParentheses = false,

--- a/ICSharpCode.NRefactory.CSharp/Formatter/FormattingVisitor_TypeMembers.cs
+++ b/ICSharpCode.NRefactory.CSharp/Formatter/FormattingVisitor_TypeMembers.cs
@@ -434,16 +434,11 @@ namespace ICSharpCode.NRefactory.CSharp
 
 			var initializer = constructorDeclaration.Initializer;
 			if (!initializer.IsNull) {
-				ForceSpacesBefore(constructorDeclaration.ColonToken, true);
-				ForceSpacesAfter(constructorDeclaration.ColonToken, true);
-				bool popIndent = initializer.StartLocation.Line != constructorDeclaration.ColonToken.StartLocation.Line;
-				if (popIndent) {
-					curIndent.Push(IndentType.Block);
-					FixIndentation(initializer);
-				}
+				curIndent.Push(IndentType.Block);
+				PlaceOnNewLine(policy.NewLineBeforeConstructorInitializerColon, constructorDeclaration.ColonToken);
+				PlaceOnNewLine(policy.NewLineAfterConstructorInitializerColon, initializer);
 				initializer.AcceptVisitor(this);
-				if (popIndent)
-					curIndent.Pop();
+				curIndent.Pop();
 			}
 			if (!constructorDeclaration.Body.IsNull) {
 				FixOpenBrace(policy.ConstructorBraceStyle, constructorDeclaration.Body.LBraceToken);

--- a/ICSharpCode.NRefactory.Tests/FormattingTests/TestTypeLevelIndentation.cs
+++ b/ICSharpCode.NRefactory.Tests/FormattingTests/TestTypeLevelIndentation.cs
@@ -940,6 +940,127 @@ class Foo
 		}
 
 		[Test]
+		public void TestConstructorInitializerColonDontCare()
+		{
+			CSharpFormattingOptions policy = FormattingOptionsFactory.CreateMono();
+			policy.NewLineAfterConstructorInitializerColon = NewLinePlacement.DoNotCare;
+			policy.NewLineBeforeConstructorInitializerColon = NewLinePlacement.DoNotCare;
+			Test(policy, @"class A
+{
+	public A ()		:			base ()
+	{
+
+	}
+
+	public A ()			: 			
+						base ()
+	{
+
+	}
+
+	public A ()
+						: 					base ()
+	{
+
+	}
+
+	public A ()				
+		     : 					
+						base ()
+	{
+
+	}
+}",
+				@"class A
+{
+	public A () : base ()
+	{
+
+	}
+
+	public A () :
+		base ()
+	{
+
+	}
+
+	public A ()
+		: base ()
+	{
+
+	}
+
+	public A ()
+		:
+		base ()
+	{
+
+	}
+}");
+		}
+
+		[Test]
+		public void TestConstructorInitializerColonNewLineBeforeSameLineAfter()
+		{
+			CSharpFormattingOptions policy = FormattingOptionsFactory.CreateMono();
+			policy.NewLineBeforeConstructorInitializerColon = NewLinePlacement.NewLine;
+			policy.NewLineAfterConstructorInitializerColon = NewLinePlacement.SameLine;
+
+			Test(policy, @"class A
+{
+	public A ()		:			base ()
+	{
+
+	}
+
+	public A ()			: 			
+						base ()
+	{
+
+	}
+
+	public A ()
+						: 					base ()
+	{
+
+	}
+
+	public A ()				
+		     : 					
+						base ()
+	{
+
+	}
+}",
+				@"class A
+{
+	public A ()
+		: base ()
+	{
+
+	}
+
+	public A ()
+		: base ()
+	{
+
+	}
+
+	public A ()
+		: base ()
+	{
+
+	}
+
+	public A ()
+		: base ()
+	{
+
+	}
+}");
+		}
+
+		[Test]
 		public void TestIndentPreprocessorStatementsAdd()
 		{
 			CSharpFormattingOptions policy = FormattingOptionsFactory.CreateMono();


### PR DESCRIPTION
Mostly what code does can be seen from unit tests...
I tested all possible scenarios I could think of(adding multiple bank lines...) and it always worked as expected.
I talked to @mkrueger what default should be in MonoDevelop he said DoNotCare.
Visual studio has Before=NewLine and After=SameLine so I did so in CreateKRStyle(is this correct placement)?
A bit extra code explaining...
ForceSpaces are not needed any more since PlaceOnNewLine takes care of that.
Always setting curIndent.Push(IndentType.Block); doesn't hurt if its all in same line but works very well for anything(colon or initializer) that is in new line.
TestConstructorInitializerColonDontCare always set DoNotCare in case Mono default change... Is this Ok or should we test defaults aswell?
