### PR TITLE
Always displaying first parameter discription in ParameterInfo tooltip

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Completion/CSharpCompletionEngineBase.cs
+++ b/ICSharpCode.NRefactory.CSharp/Completion/CSharpCompletionEngineBase.cs
@@ -169,7 +169,6 @@ namespace ICSharpCode.NRefactory.CSharp.Completion
 			var bracketStack = new Stack<Stack<int>> ();
 			bool inSingleComment = false, inString = false, inVerbatimString = false, inChar = false, inMultiLineComment = false;
 			var word = new StringBuilder ();
-			bool foundCharAfterOpenBracket = false;
 			for (int i = triggerOffset; i < endOffset; i++) {
 				char ch = document.GetCharAt (i);
 				char nextCh = i + 1 < document.TextLength ? document.GetCharAt (i + 1) : '\0';
@@ -183,8 +182,6 @@ namespace ICSharpCode.NRefactory.CSharp.Completion
 				} else {
 					word.Length = 0;
 				}
-				if (!char.IsWhiteSpace(ch) && parameter.Count > 0)
-					foundCharAfterOpenBracket = true;
 
 				switch (ch) {
 					case '{':
@@ -317,8 +314,6 @@ namespace ICSharpCode.NRefactory.CSharp.Completion
 			if (parameter.Count != 1 || bracketStack.Count > 0) {
 				return -1;
 			}
-			if (!foundCharAfterOpenBracket)
-				return 0;
 			return parameter.Pop() + 1;
 		}
 

--- a/ICSharpCode.NRefactory.Tests/CSharp/CodeCompletion/GetCurrentParameterIndexTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/CodeCompletion/GetCurrentParameterIndexTests.cs
@@ -64,7 +64,7 @@ namespace ICSharpCode.NRefactory.CSharp.CodeCompletion
 		public void TestFirstParameterStart ()
 		{
 			var index = GetIndex("@Test($");
-			Assert.AreEqual(0, index);
+			Assert.AreEqual(1, index);
 		}
 
 		[Test]


### PR DESCRIPTION
I like when I let images talk :D
![image](https://cloud.githubusercontent.com/assets/774791/2534898/2fdc6b46-b584-11e3-8040-5e10fe981e73.png)
