### PR TITLE
Improved resolving of target method for ParameterInfo

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Completion/CSharpCompletionEngineBase.cs
+++ b/ICSharpCode.NRefactory.CSharp/Completion/CSharpCompletionEngineBase.cs
@@ -339,12 +339,27 @@ namespace ICSharpCode.NRefactory.CSharp.Completion
 				this.text = text;
 			}
 
-			public void Parse(Action<char> act = null)
+			/// <summary>
+			/// Parsing all text and calling act delegate on almost every character.
+			/// Skipping begining of comments, begining of verbatim strings and escaped characters.
+			/// </summary>
+			/// <param name="act">Return true to abort parsing. Integer argument represent offset in text.</param>
+			/// <returns>True if aborted.</returns>
+			public bool Parse(Func<char, int, bool> act = null)
 			{
-				Parse(0, text.Length, act);
+				return Parse(0, text.Length, act);
 			}
 
-			public void Parse(int start, int length, Action<char> act = null)
+
+			/// <summary>
+			/// Parsing text from start to start+length and calling act delegate on almost every character.
+			/// Skipping begining of comments, begining of verbatim strings and escaped characters.
+			/// </summary>
+			/// <param name="start">Start offset.</param>
+			/// <param name="length">Lenght to parse.</param>
+			/// <param name="act">Return true to abort parsing. Integer argument represent offset in text.</param>
+			/// <returns>True if aborted.</returns>
+			public bool Parse(int start, int length, Func<char, int, bool> act = null)
 			{
 				for (int i = start; i < length; i++) {
 					char ch = text [i];
@@ -415,9 +430,11 @@ namespace ICSharpCode.NRefactory.CSharp.Completion
 							break;
 					}
 					if (act != null)
-						act(ch);
+					if (act (ch, i))
+						return true;
 					IsFistNonWs &= ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r';
 				}
+				return false;
 			}
 		}
 

--- a/ICSharpCode.NRefactory.CSharp/Completion/CSharpParameterCompletionEngine.cs
+++ b/ICSharpCode.NRefactory.CSharp/Completion/CSharpParameterCompletionEngine.cs
@@ -57,7 +57,7 @@ namespace ICSharpCode.NRefactory.CSharp.Completion
 			if (currentMember == null && currentType == null) { 
 				return null;
 			}
-			baseUnit = ParseStub("x] = a[1");
+			baseUnit = ParseStub("x]");
 			
 			//var memberLocation = currentMember != null ? currentMember.Region.Begin : currentType.Region.Begin;
 			var mref = baseUnit.GetNodeAt(location, n => n is IndexerExpression); 
@@ -183,20 +183,94 @@ namespace ICSharpCode.NRefactory.CSharp.Completion
 		
 		public IParameterDataProvider GetParameterDataProvider(int offset, char completionChar)
 		{
-			if (offset <= 0) {
+			//Ignoring completionChar == '\0' because it usually means moving with arrow keys, tab or enter
+			//we don't want to trigger on those events but it probably should be handled somewhere else
+			//since our job is to resolve method and not to decide when to display tooltip or not
+			if (offset <= 0 || completionChar == '\0') {
 				return null;
 			}
-			if (completionChar != '(' && completionChar != '<' && completionChar != '[' && completionChar != ',') {
-				return null;
-			}
-			
-			SetOffset(offset);
-			if (IsInsideCommentStringOrDirective()) {
-				return null;
+			SetOffset (offset);
+			int startOffset;
+			string text;
+			if (currentMember == null && currentType == null) {
+				//In case of attributes parse all file
+				startOffset = 0;
+				text = document.Text;
+			} else {
+				var memberText = GetMemberTextToCaret ();
+				text = memberText.Item1;
+				startOffset = document.GetOffset (memberText.Item2);
 			}
 
+			var parenStack = new Stack<int> ();
+			var chevronStack = new Stack<int> ();
+			var squareStack = new Stack<int> ();
+			var bracketStack = new Stack<int> ();
+
+			var lex = new MiniLexer (text);
+
+			bool failed = lex.Parse ((ch, off) => {
+				if (lex.IsInString || lex.IsInChar || lex.IsInVerbatimString || lex.IsInSingleComment || lex.IsInMultiLineComment || lex.IsInPreprocessorDirective)
+					return false;
+				switch (ch) {
+				case '(':
+					parenStack.Push (startOffset + off);
+					break;
+				case ')':
+					if (parenStack.Count == 0) {
+						return true;
+					}
+					parenStack.Pop ();
+					break;
+				case '<':
+					chevronStack.Push (startOffset + off);
+					break;
+				case '>':
+					if (chevronStack.Count == 0) {
+						return true;
+					}
+					chevronStack.Pop ();
+					break;
+				case '[':
+					squareStack.Push (startOffset + off);
+					break;
+				case ']':
+					if (squareStack.Count == 0) {
+						return true;
+					}
+					squareStack.Pop ();
+					break;
+				case '{':
+					bracketStack.Push (startOffset + off);
+					break;
+				case '}':
+					if (bracketStack.Count == 0) {
+						return true;
+					}
+					bracketStack.Pop ();
+					break;
+				}
+				return false;
+			});
+			if (failed)
+				return null;
+			int result = -1;
+			if (parenStack.Count > 0)
+				result = parenStack.Pop ();
+			if (squareStack.Count > 0)
+				result = Math.Max (result, squareStack.Pop ());
+			if (chevronStack.Count > 0)
+				result = Math.Max (result, chevronStack.Pop ());
+
+			//If we are inside { bracket we don't want to display anything
+			if (bracketStack.Count > 0 && bracketStack.Pop () > result)
+				return null;
+
+			if (result == -1)
+				return null;
+			SetOffset (result + 1);
 			ResolveResult resolveResult;
-			switch (completionChar) {
+			switch (document.GetCharAt (result)) {
 				case '(':
 					var invoke = GetInvocationBeforeCursor(true) ?? GetConstructorInitializerBeforeCursor();
 					if (invoke == null) {
@@ -258,62 +332,6 @@ namespace ICSharpCode.NRefactory.CSharp.Completion
 					//				if (resolvedType != null && resolvedType.ClassType == ClassType.Delegate) {
 					//					return new NRefactoryParameterDataProvider (textEditorData, result.Expression, resolvedType);
 					//				}
-					break;
-				case ',':
-					invoke = GetInvocationBeforeCursor(true) ?? GetIndexerBeforeCursor();
-					if (invoke == null) {
-						invoke = GetTypeBeforeCursor();
-						if (invoke != null) {
-							if (GetCurrentParameterIndex(document.GetOffset(invoke.Node.StartLocation), offset) < 0)
-								return null;
-							var typeExpression = ResolveExpression(invoke);
-							if (typeExpression == null || typeExpression.Result == null || typeExpression.Result.IsError) {
-								return null;
-							}
-							
-							return factory.CreateTypeParameterDataProvider(document.GetOffset(invoke.Node.StartLocation), CollectAllTypes(typeExpression.Result.Type));
-						}
-						return null;
-					}
-					if (GetCurrentParameterIndex(document.GetOffset(invoke.Node.StartLocation), offset) < 0)
-						return null;
-					if (invoke.Node is ArrayCreateExpression)
-						return null;
-					if (invoke.Node is ObjectCreateExpression) {
-						var createType = ResolveExpression(((ObjectCreateExpression)invoke.Node).Type);
-						return factory.CreateConstructorProvider(document.GetOffset(invoke.Node.StartLocation), createType.Result.Type);
-					}
-					
-					if (invoke.Node is ICSharpCode.NRefactory.CSharp.Attribute) {
-						var attribute = ResolveExpression(invoke);
-						if (attribute == null || attribute.Result == null) {
-							return null;
-						}
-						return factory.CreateConstructorProvider(document.GetOffset(invoke.Node.StartLocation), attribute.Result.Type);
-					}
-					
-					invocationExpression = ResolveExpression(invoke);
-					
-					if (invocationExpression == null || invocationExpression.Result == null || invocationExpression.Result.IsError) {
-						return null;
-					}
-					
-					resolveResult = invocationExpression.Result;
-					if (resolveResult is MethodGroupResolveResult) {
-						return factory.CreateMethodDataProvider(document.GetOffset(invoke.Node.StartLocation), CollectMethods(invoke.Node, resolveResult as MethodGroupResolveResult));
-					}
-					if (resolveResult is MemberResolveResult) {
-						if (resolveResult.Type.Kind == TypeKind.Delegate) {
-							return factory.CreateDelegateDataProvider(document.GetOffset(invoke.Node.StartLocation), resolveResult.Type);
-						}
-						var mr = resolveResult as MemberResolveResult;
-						if (mr.Member is IMethod) {
-							return factory.CreateMethodDataProvider(document.GetOffset(invoke.Node.StartLocation), new [] { (IMethod)mr.Member });
-						}
-					}
-					if (resolveResult != null) {
-						return factory.CreateIndexerParameterDataProvider(document.GetOffset(invoke.Node.StartLocation), resolveResult.Type, GetAccessibleIndexers (resolveResult.Type), invoke.Node);
-					}
 					break;
 				case '<':
 					invoke = GetMethodTypeArgumentInvocationBeforeCursor();

--- a/ICSharpCode.NRefactory.Tests/CSharp/CodeCompletion/ParameterCompletionTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/CodeCompletion/ParameterCompletionTests.cs
@@ -632,6 +632,41 @@ class TestClass
 			Assert.IsNotNull (provider, "provider was not created.");
 			Assert.AreEqual (1, provider.Count);
 		}
+
+		[Test]
+		public void TestMethodParameterWithSpacesTabsNewLines ()
+		{
+			var provider = CreateProvider (@"class TestClass
+{
+	public int TestMe (int x) { return 0; } 
+	public void Test ()
+	{
+		$TestMe ( 		  	  
+ 	
+ $
+	}
+}");
+			Assert.IsNotNull (provider, "provider was not created.");
+			Assert.AreEqual (1, provider.Count);
+		}
+        
+		[Test]
+		public void TestMethodParameterNestedArray ()
+		{
+		    var provider = CreateProvider (@"using System;
+
+class TestClass
+{
+	TestClass ()
+	{
+		var str = new string[2,2];
+		$Console.WriteLine ( str [1,$
+	}
+}
+");
+			Assert.IsNotNull (provider, "provider was not created.");
+			Assert.AreEqual (1, provider.Count);
+		}
 		
 		
 		/// Bug 599 - Regression: No intellisense over Func delegate


### PR DESCRIPTION
This is not full pull request but I'm mostly looking for your opinion if I'm approaching this correctly... Because I want to test a bit more stuff around when Window is displayed and hidden...

Is it acceptable that I changed public MiniLexer interface here I mean

``` csharp
public void Parse(Action<char> act = null)
```

to

``` csharp
public bool Parse(Func<char, int, bool> act = null)
```

Should I keep old one and new one as overload? Atm to my knowledge its only used here: https://github.com/mono/monodevelop/blob/master/main/src/addins/CSharpBinding/MonoDevelop.CSharp.Formatting/OnTheFlyFormatter.cs#L119

baseUnit = ParseStub("x] = a[1"); change to baseUnit = ParseStub("x]"); based on my testing this is much better in cases when we are inside other invocations. I really can't see reason why "= a[1" is necessary... Hoping someone can enlighten me :) 

Is it OK that I'm ignoring completionChar because I'm now depending only on offset could this cause any problems?

I threw out whole of comma because in case of "Console.WriteLine(str[0,$"(See UnitTest for whole example)
It tried to first with invocation:

``` csharp
invoke = GetInvocationBeforeCursor(true) ?? GetIndexerBeforeCursor();
```

which was wrong because it should with

``` csharp
invoke = GetIndexerBeforeCursor();
```

Because now I'm stepping backward to first [,( or < we don't have to worry about comma anymore...

I'm also working on much better overload picking because currently it only looks at number of parameters and not arguments/parameters type matching but I want to do this stuff in multiple pulls to be more digestible :)
