### PR TITLE
[CodeIssues] Add simplified versions Math functions.

### DIFF
--- a/ICSharpCode.NRefactory.CSharp.Refactoring/CodeIssues/Synced/PracticesAndImprovements/ReplaceWithSingleCallToAverageIssue.cs
+++ b/ICSharpCode.NRefactory.CSharp.Refactoring/CodeIssues/Synced/PracticesAndImprovements/ReplaceWithSingleCallToAverageIssue.cs
@@ -1,0 +1,123 @@
+﻿// 
+// ReplaceWithSingleCallToAverageIssue.cs
+//
+// Author:
+//       Marius Ungureanu <marius.ungureanu@xamarin.com>
+// 
+// Copyright (c) 2014 Xamarin <http://xamarin.com>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System.Linq;
+using ICSharpCode.NRefactory.Semantics;
+using ICSharpCode.NRefactory.TypeSystem;
+using ICSharpCode.NRefactory.PatternMatching;
+using ICSharpCode.NRefactory.Refactoring;
+
+namespace ICSharpCode.NRefactory.CSharp.Refactoring
+{
+	[IssueDescription("Replace with single call to Average(...)",
+		Description = "Replace with single call to Average(...)",
+		Category = IssueCategories.PracticesAndImprovements,
+		Severity = Severity.Suggestion,
+		AnalysisDisableKeyword = "ReplaceWithSingleCallToAverage")]
+	public class ReplaceWithSingleCallToAverageIssue : GatherVisitorCodeIssueProvider
+	{
+		static readonly AstNode pattern =
+			new InvocationExpression (
+				new MemberReferenceExpression (
+					new NamedNode ("selectInvoke",
+						new InvocationExpression (
+							new MemberReferenceExpression (new AnyNode ("target"), "Select"),
+							new AnyNode ())),
+					Pattern.AnyString));
+
+		protected override IGatherVisitor CreateVisitor(BaseRefactoringContext context)
+		{
+			return new GatherVisitor<ReplaceWithSingleCallToAverageIssue>(context, "Average");
+		}
+
+		internal class GatherVisitor<T> : GatherVisitorBase<T> where T : GatherVisitorCodeIssueProvider
+		{
+			readonly string member;
+
+			public GatherVisitor (BaseRefactoringContext ctx, string member) : base (ctx)
+			{
+				this.member = member;
+			}
+
+			public override void VisitInvocationExpression (InvocationExpression invocationExpression)
+			{
+				base.VisitInvocationExpression (invocationExpression);
+
+				var match = pattern.Match (invocationExpression);
+				if (!match.Success)
+					return;
+
+				var averageResolve = ctx.Resolve (invocationExpression) as InvocationResolveResult;
+				if (averageResolve == null || !HasPredicateVersion(averageResolve.Member))
+					return;
+				var selectInvoke = match.Get<InvocationExpression> ("selectInvoke").Single ();
+				var selectResolve = ctx.Resolve (selectInvoke) as InvocationResolveResult;
+				if (selectResolve == null || selectResolve.Member.Name != "Select" || !IsQueryExtensionClass(selectResolve.Member.DeclaringTypeDefinition))
+					return;
+				if (selectResolve.Member.Parameters.Count != 2)
+					return;
+				var predResolve = selectResolve.Member.Parameters [1];
+				if (predResolve.Type.TypeParameterCount != 2)
+					return;
+
+				AddIssue(new CodeIssue(
+					invocationExpression, string.Format(ctx.TranslateString("Redundant Select() call with predicate followed by {0}()"), averageResolve.Member.Name),
+					new CodeAction (
+						string.Format(ctx.TranslateString("Replace with single call to '{0}'"), averageResolve.Member.Name),
+						script => {
+							var arg = selectInvoke.Arguments.Single ().Clone ();
+							var target = match.Get<Expression> ("target").Single ().Clone ();
+							script.Replace (invocationExpression, new InvocationExpression (new MemberReferenceExpression (target, averageResolve.Member.Name), arg));
+						},
+						invocationExpression
+					)
+				));
+			}
+
+			static bool IsQueryExtensionClass(ITypeDefinition typeDef)
+			{
+				if (typeDef == null || typeDef.Namespace != "System.Linq")
+					return false;
+				switch (typeDef.Name) {
+					case "Enumerable":
+					case "ParallelEnumerable":
+					case "Queryable":
+						return true;
+					default:
+						return false;
+				}
+			}
+
+			bool HasPredicateVersion(IParameterizedMember member)
+			{
+				if (!IsQueryExtensionClass(member.DeclaringTypeDefinition))
+					return false;
+				return member.Name == this.member;
+			}
+		}
+	}
+}
+
+

--- a/ICSharpCode.NRefactory.CSharp.Refactoring/CodeIssues/Synced/PracticesAndImprovements/ReplaceWithSingleCallToMaxIssue.cs
+++ b/ICSharpCode.NRefactory.CSharp.Refactoring/CodeIssues/Synced/PracticesAndImprovements/ReplaceWithSingleCallToMaxIssue.cs
@@ -1,0 +1,43 @@
+﻿// 
+// ReplaceWithSingleCallToMaxIssue.cs
+//
+// Author:
+//       Marius Ungureanu <marius.ungureanu@xamarin.com>
+// 
+// Copyright (c) 2014 Xamarin <http://xamarin.com>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using ICSharpCode.NRefactory.Refactoring;
+
+namespace ICSharpCode.NRefactory.CSharp.Refactoring
+{
+	[IssueDescription("Replace with single call to Max(...)",
+		Description = "Replace with single call to Max(...)",
+		Category = IssueCategories.PracticesAndImprovements,
+		Severity = Severity.Suggestion,
+		AnalysisDisableKeyword = "ReplaceWithSingleCallToMax")]
+	public class ReplaceWithSingleCallToMaxIssue : GatherVisitorCodeIssueProvider
+	{
+		protected override IGatherVisitor CreateVisitor(BaseRefactoringContext context)
+		{
+			return new ReplaceWithSingleCallToAverageIssue.GatherVisitor<ReplaceWithSingleCallToMaxIssue>(context, "Max");
+		}
+	}
+}
+

--- a/ICSharpCode.NRefactory.CSharp.Refactoring/CodeIssues/Synced/PracticesAndImprovements/ReplaceWithSingleCallToMinIssue.cs
+++ b/ICSharpCode.NRefactory.CSharp.Refactoring/CodeIssues/Synced/PracticesAndImprovements/ReplaceWithSingleCallToMinIssue.cs
@@ -1,0 +1,43 @@
+﻿// 
+// ReplaceWithSingleCallToMinIssue.cs
+//
+// Author:
+//       Marius Ungureanu <marius.ungureanu@xamarin.com>
+// 
+// Copyright (c) 2014 Xamarin <http://xamarin.com>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using ICSharpCode.NRefactory.Refactoring;
+
+namespace ICSharpCode.NRefactory.CSharp.Refactoring
+{
+	[IssueDescription("Replace with single call to Min(...)",
+		Description = "Replace with single call to Min(...)",
+		Category = IssueCategories.PracticesAndImprovements,
+		Severity = Severity.Suggestion,
+		AnalysisDisableKeyword = "ReplaceWithSingleCallToMin")]
+	public class ReplaceWithSingleCallToMinIssue : GatherVisitorCodeIssueProvider
+	{
+		protected override IGatherVisitor CreateVisitor(BaseRefactoringContext context)
+		{
+			return new ReplaceWithSingleCallToAverageIssue.GatherVisitor<ReplaceWithSingleCallToMinIssue>(context, "Min");
+		}
+	}
+}
+

--- a/ICSharpCode.NRefactory.CSharp.Refactoring/CodeIssues/Synced/PracticesAndImprovements/ReplaceWithSingleCallToSumIssue.cs
+++ b/ICSharpCode.NRefactory.CSharp.Refactoring/CodeIssues/Synced/PracticesAndImprovements/ReplaceWithSingleCallToSumIssue.cs
@@ -1,0 +1,43 @@
+﻿// 
+// ReplaceWithSingleCallToSumIssue.cs
+//
+// Author:
+//       Marius Ungureanu <marius.ungureanu@xamarin.com>
+// 
+// Copyright (c) 2014 Xamarin <http://xamarin.com>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using ICSharpCode.NRefactory.Refactoring;
+
+namespace ICSharpCode.NRefactory.CSharp.Refactoring
+{
+	[IssueDescription("Replace with single call to Sum(...)",
+		Description = "Replace with single call to Sum(...)",
+		Category = IssueCategories.PracticesAndImprovements,
+		Severity = Severity.Suggestion,
+		AnalysisDisableKeyword = "ReplaceWithSingleCallToSum")]
+	public class ReplaceWithSingleCallToSumIssue : GatherVisitorCodeIssueProvider
+	{
+		protected override IGatherVisitor CreateVisitor(BaseRefactoringContext context)
+		{
+			return new ReplaceWithSingleCallToAverageIssue.GatherVisitor<ReplaceWithSingleCallToSumIssue>(context, "Sum");
+		}
+	}
+}
+

--- a/ICSharpCode.NRefactory.CSharp.Refactoring/ICSharpCode.NRefactory.CSharp.Refactoring.csproj
+++ b/ICSharpCode.NRefactory.CSharp.Refactoring/ICSharpCode.NRefactory.CSharp.Refactoring.csproj
@@ -427,6 +427,10 @@
     <Compile Include="CodeIssues\Custom\CompilerErrors\ExpressionIsNeverOfProvidedTypeIssue.cs" />
     <Compile Include="CodeIssues\Custom\RedundantAssignmentIssue.cs" />
     <Compile Include="CodeIssues\Custom\UnreachableCodeIssue.cs" />
+    <Compile Include="CodeIssues\Synced\PracticesAndImprovements\ReplaceWithSingleCallToMinIssue.cs" />
+    <Compile Include="CodeIssues\Synced\PracticesAndImprovements\ReplaceWithSingleCallToMaxIssue.cs" />
+    <Compile Include="CodeIssues\Synced\PracticesAndImprovements\ReplaceWithSingleCallToAverageIssue.cs" />
+    <Compile Include="CodeIssues\Synced\PracticesAndImprovements\ReplaceWithSingleCallToSumIssue.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/ReplaceWithSingleCallToAverageIssueTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/ReplaceWithSingleCallToAverageIssueTests.cs
@@ -1,0 +1,77 @@
+﻿// 
+// ReplaceWithSingleCallToAverageTests.cs
+//
+// Author:
+//       Marius Ungureanu <marius.ungureanu@xamarin.com>
+// 
+// Copyright (c) 2014 Xamarin <http://xamarin.com>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using NUnit.Framework;
+using ICSharpCode.NRefactory.CSharp.Refactoring;
+using ICSharpCode.NRefactory.CSharp.CodeActions;
+
+namespace ICSharpCode.NRefactory.CSharp.CodeIssues
+{
+	[TestFixture]
+	public class ReplaceWithSingleCallToAverageIssueTests : InspectionActionTestBase
+	{
+		[Test]
+		public void TestSimpleCase()
+		{
+			var input = @"using System.Linq;
+public class CSharpDemo {
+	public void Bla () {
+		int[] arr;
+		var bla = arr.Select (x => x * 2).Average ();
+	}
+}";
+
+			TestRefactoringContext context;
+			var issues = GetIssues(new ReplaceWithSingleCallToAverageIssue(), input, out context);
+			Assert.AreEqual(1, issues.Count);
+			CheckFix(context, issues, @"using System.Linq;
+public class CSharpDemo {
+	public void Bla () {
+		int[] arr;
+		var bla = arr.Average (x => x * 2);
+	}
+}");
+		}
+
+		[Test]
+		public void TestDisable()
+		{
+			var input = @"using System.Linq;
+public class CSharpDemo {
+	public void Bla () {
+		int[] arr;
+// ReSharper disable ReplaceWithSingleCallToAverage
+		var bla = arr.Select (x => x * 2).Average ();
+	}
+}";
+
+			TestRefactoringContext context;
+			var issues = GetIssues(new ReplaceWithSingleCallToAverageIssue(), input, out context);
+			Assert.AreEqual(0, issues.Count);
+		}
+	}
+}

--- a/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/ReplaceWithSingleCallToMaxIssueTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/ReplaceWithSingleCallToMaxIssueTests.cs
@@ -1,0 +1,77 @@
+﻿// 
+// ReplaceWithSingleCallToMaxTests.cs
+//
+// Author:
+//       Marius Ungureanu <marius.ungureanu@xamarin.com>
+// 
+// Copyright (c) 2014 Xamarin <http://xamarin.com>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using NUnit.Framework;
+using ICSharpCode.NRefactory.CSharp.Refactoring;
+using ICSharpCode.NRefactory.CSharp.CodeActions;
+
+namespace ICSharpCode.NRefactory.CSharp.CodeIssues
+{
+	[TestFixture]
+	public class ReplaceWithSingleCallToMaxIssueTests : InspectionActionTestBase
+	{
+		[Test]
+		public void TestSimpleCase()
+		{
+			var input = @"using System.Linq;
+public class CSharpDemo {
+	public void Bla () {
+		int[] arr;
+		var bla = arr.Select (x => x * 2).Max ();
+	}
+}";
+
+			TestRefactoringContext context;
+			var issues = GetIssues(new ReplaceWithSingleCallToMaxIssue(), input, out context);
+			Assert.AreEqual(1, issues.Count);
+			CheckFix(context, issues, @"using System.Linq;
+public class CSharpDemo {
+	public void Bla () {
+		int[] arr;
+		var bla = arr.Max (x => x * 2);
+	}
+}");
+		}
+
+		[Test]
+		public void TestDisable()
+		{
+			var input = @"using System.Linq;
+public class CSharpDemo {
+	public void Bla () {
+		int[] arr;
+// ReSharper disable ReplaceWithSingleCallToMax
+		var bla = arr.Select (x => x * 2).Max ();
+	}
+}";
+
+			TestRefactoringContext context;
+			var issues = GetIssues(new ReplaceWithSingleCallToMaxIssue(), input, out context);
+			Assert.AreEqual(0, issues.Count);
+		}
+	}
+}

--- a/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/ReplaceWithSingleCallToMinIssueTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/ReplaceWithSingleCallToMinIssueTests.cs
@@ -1,0 +1,77 @@
+﻿// 
+// ReplaceWithSingleCallToMinTests.cs
+//
+// Author:
+//       Marius Ungureanu <marius.ungureanu@xamarin.com>
+// 
+// Copyright (c) 2014 Xamarin <http://xamarin.com>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using NUnit.Framework;
+using ICSharpCode.NRefactory.CSharp.Refactoring;
+using ICSharpCode.NRefactory.CSharp.CodeActions;
+
+namespace ICSharpCode.NRefactory.CSharp.CodeIssues
+{
+	[TestFixture]
+	public class ReplaceWithSingleCallToMinIssueTests : InspectionActionTestBase
+	{
+		[Test]
+		public void TestSimpleCase()
+		{
+			var input = @"using System.Linq;
+public class CSharpDemo {
+	public void Bla () {
+		int[] arr;
+		var bla = arr.Select (x => x * 2).Min ();
+	}
+}";
+
+			TestRefactoringContext context;
+			var issues = GetIssues(new ReplaceWithSingleCallToMinIssue(), input, out context);
+			Assert.AreEqual(1, issues.Count);
+			CheckFix(context, issues, @"using System.Linq;
+public class CSharpDemo {
+	public void Bla () {
+		int[] arr;
+		var bla = arr.Min (x => x * 2);
+	}
+}");
+		}
+
+		[Test]
+		public void TestDisable()
+		{
+			var input = @"using System.Linq;
+public class CSharpDemo {
+	public void Bla () {
+		int[] arr;
+// ReSharper disable ReplaceWithSingleCallToMin
+		var bla = arr.Select (x => x * 2).Min ();
+	}
+}";
+
+			TestRefactoringContext context;
+			var issues = GetIssues(new ReplaceWithSingleCallToMinIssue(), input, out context);
+			Assert.AreEqual(0, issues.Count);
+		}
+	}
+}

--- a/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/ReplaceWithSingleCallToSumIssueTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/CodeIssues/ReplaceWithSingleCallToSumIssueTests.cs
@@ -1,0 +1,77 @@
+﻿// 
+// ReplaceWithSingleCallToSumTests.cs
+//
+// Author:
+//       Marius Ungureanu <marius.ungureanu@xamarin.com>
+// 
+// Copyright (c) 2014 Xamarin <http://xamarin.com>
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+using System;
+using NUnit.Framework;
+using ICSharpCode.NRefactory.CSharp.Refactoring;
+using ICSharpCode.NRefactory.CSharp.CodeActions;
+
+namespace ICSharpCode.NRefactory.CSharp.CodeIssues
+{
+	[TestFixture]
+	public class ReplaceWithSingleCallToSumIssueTests : InspectionActionTestBase
+	{
+		[Test]
+		public void TestSimpleCase()
+		{
+			var input = @"using System.Linq;
+public class CSharpDemo {
+	public void Bla () {
+		int[] arr;
+		var bla = arr.Select (x => x * 2).Sum ();
+	}
+}";
+
+			TestRefactoringContext context;
+			var issues = GetIssues(new ReplaceWithSingleCallToSumIssue(), input, out context);
+			Assert.AreEqual(1, issues.Count);
+			CheckFix(context, issues, @"using System.Linq;
+public class CSharpDemo {
+	public void Bla () {
+		int[] arr;
+		var bla = arr.Sum (x => x * 2);
+	}
+}");
+		}
+
+		[Test]
+		public void TestDisable()
+		{
+			var input = @"using System.Linq;
+public class CSharpDemo {
+	public void Bla () {
+		int[] arr;
+// ReSharper disable ReplaceWithSingleCallToSum
+		var bla = arr.Select (x => x * 2).Sum ();
+	}
+}";
+
+			TestRefactoringContext context;
+			var issues = GetIssues(new ReplaceWithSingleCallToSumIssue(), input, out context);
+			Assert.AreEqual(0, issues.Count);
+		}
+	}
+}

--- a/ICSharpCode.NRefactory.Tests/ICSharpCode.NRefactory.Tests.csproj
+++ b/ICSharpCode.NRefactory.Tests/ICSharpCode.NRefactory.Tests.csproj
@@ -618,6 +618,10 @@
     <Compile Include="CSharp\CodeIssues\StaticEventSubscriptionIssueTests.cs" />
     <Compile Include="CSharp\CodeActions\CS1105ExtensionMethodMustBeDeclaredStaticActionTests.cs" />
     <Compile Include="CSharp\CodeIssues\UnmatchedSizeSpeicificationInArrayCreationTests.cs" />
+    <Compile Include="CSharp\CodeIssues\ReplaceWithSingleCallToMaxIssueTests.cs" />
+    <Compile Include="CSharp\CodeIssues\ReplaceWithSingleCallToMinIssueTests.cs" />
+    <Compile Include="CSharp\CodeIssues\ReplaceWithSingleCallToSumIssueTests.cs" />
+    <Compile Include="CSharp\CodeIssues\ReplaceWithSingleCallToAverageIssueTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\cecil\Mono.Cecil.csproj">


### PR DESCRIPTION
This covers the cases where we have Transformer().Transformer() just like Selectors are handled by Where().OtherSelector().
