### PR TITLE
Fixing parameter code completion after using '>' e.g. if(a>b)Method(

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/Completion/CSharpParameterCompletionEngine.cs
+++ b/ICSharpCode.NRefactory.CSharp/Completion/CSharpParameterCompletionEngine.cs
@@ -208,7 +208,6 @@ namespace ICSharpCode.NRefactory.CSharp.Completion
 			var bracketStack = new Stack<int> ();
 
 			var lex = new MiniLexer (text);
-			char lastChar = '0';
 			bool failed = lex.Parse ((ch, off) => {
 				if (lex.IsInString || lex.IsInChar || lex.IsInVerbatimString || lex.IsInSingleComment || lex.IsInMultiLineComment || lex.IsInPreprocessorDirective)
 					return false;
@@ -226,10 +225,9 @@ namespace ICSharpCode.NRefactory.CSharp.Completion
 					chevronStack.Push (startOffset + off);
 					break;
 				case '>':
-					if (lastChar == '=')
-						break;
+					//Don't abort if we don't have macthing '<' for '>' it could be if (i > 0) Foo($
 					if (chevronStack.Count == 0) {
-						return true;
+						return false;
 					}
 					chevronStack.Pop ();
 					break;
@@ -252,7 +250,6 @@ namespace ICSharpCode.NRefactory.CSharp.Completion
 					bracketStack.Pop ();
 					break;
 				}
-				lastChar = ch;
 				return false;
 			});
 			if (failed)

--- a/ICSharpCode.NRefactory.Tests/CSharp/CodeCompletion/ParameterCompletionTests.cs
+++ b/ICSharpCode.NRefactory.Tests/CSharp/CodeCompletion/ParameterCompletionTests.cs
@@ -1265,7 +1265,6 @@ class NUnitTestClass {
 		/// <summary>
 		/// Bug 12824 - Invalid argument intellisense inside lambda
 		/// </summary>
-		[Ignore("Parser bug.")]
 		[Test]
 		public void TestBug12824 ()
 		{
@@ -1284,6 +1283,24 @@ public class MyEventArgs
 }");
 			string name = provider.Data.First().FullName;
 			Assert.AreEqual ("System.Exception..ctor", name);
+		}
+
+		[Test]
+		public void TestAfterGreaterSign ()
+		{
+			var provider = CreateProvider (@"
+class Test
+{
+	static void Foo (int num) {}
+	public static void Main (string[] args)
+	{
+		int i = 0;
+		if (i > 0)
+			Foo ($
+	}
+}");
+			Assert.AreEqual (1, provider.Count);
+			Assert.AreEqual (1, provider.GetParameterCount (0));
 		}
 	}
 }


### PR DESCRIPTION
This regression was introduced with https://github.com/icsharpcode/NRefactory/pull/392
