### PR TITLE
Added NuGet restore(when used outside NRefactory.sln) & Tests project use NuGet

### DIFF
--- a/ICSharpCode.NRefactory.CSharp.Refactoring/ICSharpCode.NRefactory6.CSharp.Refactoring.csproj
+++ b/ICSharpCode.NRefactory.CSharp.Refactoring/ICSharpCode.NRefactory6.CSharp.Refactoring.csproj
@@ -476,4 +476,18 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
+  <!--Target below is executed only when $(SolutionDir) is not one folder above from this.csproj(so not when used in NRefactory.sln).
+      This is useful when project is included in other solutions then NRefactory.sln(e.g. as git submodule) in IDE project.
+      In that case NuGet restores packages in Packages folder of that solution and not in ..\Packages where this project references expect:
+      <Reference Include="Some.NuGet.Project">
+        <HintPath>..\packages\Some.NuGet.Project\lib\net45\Some.NuGet.Project.dll</HintPath>
+      </Reference>
+  -->
+  <Target Name="RestorePackages" AfterTargets="EnsureNuGetPackageBuildImports">
+    <PropertyGroup>
+      <NuGet>$(SolutionDir)\.nuget\NuGet.exe</NuGet>
+      <NuGet Condition="$(OS)=='Unix'">mono $(NuGet)</NuGet>
+    </PropertyGroup>
+    <Exec Condition="$(SolutionDir) != $([System.IO.Path]::GetFullPath('..'))" Command="$(NuGet) restore -SolutionDirectory .." />
+  </Target>
 </Project>

--- a/ICSharpCode.NRefactory.CSharp/ICSharpCode.NRefactory6.CSharp.csproj
+++ b/ICSharpCode.NRefactory.CSharp/ICSharpCode.NRefactory6.CSharp.csproj
@@ -188,4 +188,18 @@
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
   </Target>
+  <!--Target below is executed only when $(SolutionDir) is not one folder above from this.csproj(so not when used in NRefactory.sln).
+      This is useful when project is included in other solutions then NRefactory.sln(e.g. as git submodule) in IDE project.
+      In that case NuGet restores packages in Packages folder of that solution and not in ..\Packages where this project references expect:
+      <Reference Include="Some.NuGet.Project">
+        <HintPath>..\packages\Some.NuGet.Project\lib\net45\Some.NuGet.Project.dll</HintPath>
+      </Reference>
+  -->
+  <Target Name="RestorePackages" AfterTargets="EnsureNuGetPackageBuildImports">
+    <PropertyGroup>
+      <NuGet>$(SolutionDir)\.nuget\NuGet.exe</NuGet>
+      <NuGet Condition="$(OS)=='Unix'">mono $(NuGet)</NuGet>
+    </PropertyGroup>
+    <Exec Condition="$(SolutionDir) != $([System.IO.Path]::GetFullPath('..'))" Command="$(NuGet) restore -SolutionDirectory .." />
+  </Target>
 </Project>

--- a/ICSharpCode.NRefactory.Tests/ICSharpCode.NRefactory6.Tests.csproj
+++ b/ICSharpCode.NRefactory.Tests/ICSharpCode.NRefactory6.Tests.csproj
@@ -93,34 +93,52 @@
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.ComponentModel.Composition" />
     <Reference Include="System.Collections.Immutable">
-      <HintPath>..\..\roslyn\Binaries\Debug\System.Collections.Immutable.dll</HintPath>
+      <HintPath>..\packages\System.Collections.Immutable.1.1.32-beta\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis">
-      <HintPath>..\..\roslyn\Binaries\Debug\Microsoft.CodeAnalysis.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces">
-      <HintPath>..\..\roslyn\Binaries\Debug\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp">
-      <HintPath>..\..\roslyn\Binaries\Debug\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.CSharp.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Desktop">
-      <HintPath>..\..\roslyn\Binaries\Debug\Microsoft.CodeAnalysis.CSharp.Desktop.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.CSharp.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Desktop">
-      <HintPath>..\..\roslyn\Binaries\Debug\Microsoft.CodeAnalysis.Desktop.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="System.Composition.AttributedModel">
-      <HintPath>..\..\roslyn\Binaries\Debug\System.Composition.AttributedModel.dll</HintPath>
+      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.AttributedModel.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.Workspaces.Desktop">
-      <HintPath>..\..\roslyn\Binaries\Debug\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Workspaces.Common.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.Workspaces.Desktop.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces">
-      <HintPath>..\..\roslyn\Binaries\Debug\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework">
       <HintPath>..\packages\NUnit.2.6.3\lib\nunit.framework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CodeAnalysis.CSharp.Workspaces.Desktop">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.CSharp.Workspaces.1.0.0-beta1-20141031-01\lib\net45\Microsoft.CodeAnalysis.CSharp.Workspaces.Desktop.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Composition.Convention">
+      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Convention.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Composition.Hosting">
+      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Hosting.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Composition.Runtime">
+      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.Runtime.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Composition.TypedParts">
+      <HintPath>..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Reflection.Metadata">
+      <HintPath>..\packages\System.Reflection.Metadata.1.0.17-beta\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -500,5 +518,19 @@
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
+  </Target>
+  <!--Target below is executed only when $(SolutionDir) is not one folder above from this.csproj(so not when used in NRefactory.sln).
+      This is useful when project is included in other solutions then NRefactory.sln(e.g. as git submodule) in IDE project.
+      In that case NuGet restores packages in Packages folder of that solution and not in ..\Packages where this project references expect:
+      <Reference Include="Some.NuGet.Project">
+        <HintPath>..\packages\Some.NuGet.Project\lib\net45\Some.NuGet.Project.dll</HintPath>
+      </Reference>
+  -->
+  <Target Name="RestorePackages" AfterTargets="EnsureNuGetPackageBuildImports">
+    <PropertyGroup>
+      <NuGet>$(SolutionDir)\.nuget\NuGet.exe</NuGet>
+      <NuGet Condition="$(OS)=='Unix'">mono $(NuGet)</NuGet>
+    </PropertyGroup>
+    <Exec Condition="$(SolutionDir) != $([System.IO.Path]::GetFullPath('..'))" Command="$(NuGet) restore -SolutionDirectory .." />
   </Target>
 </Project>

--- a/ICSharpCode.NRefactory.Tests/packages.config
+++ b/ICSharpCode.NRefactory.Tests/packages.config
@@ -1,4 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="NUnit" version="2.6.3" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0-beta1-20141031-01" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0-beta1-20141031-01" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0-beta1-20141031-01" targetFramework="net45" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0-beta1-20141031-01" targetFramework="net45" />
+  <package id="Microsoft.Composition" version="1.0.27" targetFramework="net45" />
+  <package id="System.Collections.Immutable" version="1.1.32-beta" targetFramework="net45" />
+  <package id="System.Reflection.Metadata" version="1.0.17-beta" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
As comment in .csproj files already explains... If project is included in solution that has Packages folder different then ../Packages(relative to project) when NuGet packages are restored. Project won't see dlls because they won't be at ../Packages but in something like ../../../../packages in case of MonoDevelop...

I also talked with Matt if he know any better solution... Unfortunately until NuGet 3.0 there is no clean solution...

Also changed unit test project to use NuGets...