### PR TITLE
Final commit LockThis :analyzer + code fix provider + tests

### DIFF
--- a/NR6Pack.Tests/CSharp/Diagnostics/LockThisTests.cs
+++ b/NR6Pack.Tests/CSharp/Diagnostics/LockThisTests.cs
@@ -29,7 +29,6 @@ using NUnit.Framework;
 namespace ICSharpCode.NRefactory6.CSharp.Diagnostics
 {
 	[TestFixture]
-	[Ignore("TODO: Issue not ported yet")]
 	public class LockThisTests : InspectionActionTestBase
 	{
 		[Test]
@@ -40,7 +39,7 @@ class TestClass
 {
 	void TestMethod ()
 	{
-		lock (this) {
+		$lock (this)$ {
 		}
 	}
 }";
@@ -56,7 +55,7 @@ class TestClass
 	}
 }";
 
-			Test<LockThisAnalyzer> (input, 1, output);
+			Analyze<LockThisAnalyzer> (input, output,1);
 		}
 
 		[Test]
@@ -67,7 +66,7 @@ class TestClass
 {
 	int MyProperty {
 		get {
-			lock (this) {
+		$lock (this)$ {
 				return 0;
 			}
 		}
@@ -87,10 +86,10 @@ class TestClass
 	}
 }";
 
-			Test<LockThisAnalyzer> (input, 1, output);
-		}
+            Analyze<LockThisAnalyzer>(input, output, 1);
+        }
 
-		[Test]
+        [Test]
 		public void TestLockThisInSetter ()
 		{
 			var input = @"
@@ -98,7 +97,7 @@ class TestClass
 {
 	int MyProperty {
 		set {
-			lock (this) {
+		$lock (this)$ {
 			}
 		}
 	}
@@ -116,10 +115,10 @@ class TestClass
 	}
 }";
 
-			Test<LockThisAnalyzer> (input, 1, output);
-		}
+            Analyze<LockThisAnalyzer>(input, output, 1);
+        }
 
-		[Test]
+        [Test]
 		public void TestLockThisInConstructor ()
 		{
 			var input = @"
@@ -127,7 +126,7 @@ class TestClass
 {
 	TestClass()
 	{
-		lock (this) {
+		$lock (this)$ {
 		}
 	}
 }";
@@ -143,10 +142,10 @@ class TestClass
 	}
 }";
 
-			Test<LockThisAnalyzer> (input, 1, output);
-		}
+            Analyze<LockThisAnalyzer>(input, output, 1);
+        }
 
-		[Test]
+        [Test]
 		public void TestLockThisInDelegate ()
 		{
 			var input = @"
@@ -156,7 +155,7 @@ class TestClass
 	{
 		Action lockThis = delegate ()
 		{
-			lock (this) {
+		$lock (this)$ {
 			}
 		};
 	}
@@ -176,10 +175,10 @@ class TestClass
 	}
 }";
 
-			Test<LockThisAnalyzer> (input, 1, output);
-		}
+            Analyze<LockThisAnalyzer>(input, output, 1);
+        }
 
-		[Test]
+        [Test]
 		public void TestLockThisInLambda ()
 		{
 			var input = @"
@@ -189,7 +188,7 @@ class TestClass
 	{
 		Action lockThis = () =>
 		{
-			lock (this) {
+		$lock (this)$ {
 			}
 		};
 	}
@@ -209,10 +208,10 @@ class TestClass
 	}
 }";
 
-			Test<LockThisAnalyzer> (input, 1, output);
-		}
+            Analyze<LockThisAnalyzer>(input, output, 1);
+        }
 
-		[Test]
+        [Test] //For some reason, the test says this test does not create any diagnostics....
 		public void TestLockParenthesizedThis ()
 		{
 			var input = @"
@@ -220,7 +219,7 @@ class TestClass
 {
 	void TestMethod ()
 	{
-		lock ((this)) {
+		$lock ((this))$ {
 		}
 	}
 }";
@@ -236,10 +235,10 @@ class TestClass
 	}
 }";
 
-			Test<LockThisAnalyzer> (input, 1, output);
-		}
+            Analyze<LockThisAnalyzer>(input, output, 1); 
+        }
 
-		[Test]
+        [Test]
 		public void TestFixMultipleLockThis ()
 		{
 			var input = @"
@@ -247,13 +246,13 @@ class TestClass
 {
 	void TestMethod ()
 	{
-		lock (this) {
+		$lock (this)$ {
 		}
 	}
 
 	void TestMethod2 ()
 	{
-		lock (this) {
+		$lock (this)$ {
 		}
 	}
 }";
@@ -275,9 +274,9 @@ class TestClass
 	}
 }";
 
-			Test<LockThisAnalyzer> (input, 2, output, 0);
-		}
-		[Test]
+            Analyze<LockThisAnalyzer>(input, output, 2);
+        }
+        [Test]
 		public void TestFixMixedLocks ()
 		{
 			var input = @"
@@ -285,7 +284,7 @@ class TestClass
 {
 	void TestMethod ()
 	{
-		lock (this) {
+		$lock (this)$ {
 		}
 	}
 
@@ -315,10 +314,10 @@ class TestClass
 	}
 }";
 
-			Test<LockThisAnalyzer> (input, 1, output);
-		}
+            Analyze<LockThisAnalyzer>(input, output, 1);
+        }
 
-		[Test]
+        [Test]
 		public void TestLockNonThis ()
 		{
 			var input = @"
@@ -333,7 +332,7 @@ class TestClass
 	}
 }";
 
-			Test<LockThisAnalyzer> (input, 0);
+			Analyze<LockThisAnalyzer> (input, null,0);
 		}
 
 		[Test]
@@ -346,7 +345,7 @@ class TestClass
 	{
 		Nested()
 		{
-			lock (this) {
+		    $lock (this)$ {
 			}
 		}
 	}
@@ -366,17 +365,17 @@ class TestClass
 	}
 }";
 
-			Test<LockThisAnalyzer>(input, 1, output);
-		}
+            Analyze<LockThisAnalyzer>(input, output, 1);
+        }
 
-		[Test]
+        [Test]
 		public void TestMethodSynchronized ()
 		{
 			var input = @"
 using System.Runtime.CompilerServices;
 class TestClass
 {
-	[MethodImpl (MethodImplOptions.Synchronized)]
+	$[MethodImpl (MethodImplOptions.Synchronized)]$
 	void TestMethod ()
 	{
 		System.Console.WriteLine (""Foo"");
@@ -396,17 +395,17 @@ class TestClass
 	}
 }";
 
-			Test<LockThisAnalyzer> (input, 1, output);
-		}
+            Analyze<LockThisAnalyzer>(input, output, 1);
+        }
 
-		[Test]
+        [Test]
 		public void TestMethodWithSynchronizedValue ()
 		{
 			var input = @"
 using System.Runtime.CompilerServices;
 class TestClass
 {
-	[MethodImpl (Value = MethodImplOptions.Synchronized)]
+	$[MethodImpl (Value = MethodImplOptions.Synchronized)]$
 	void TestMethod ()
 	{
 		System.Console.WriteLine (""Foo"");
@@ -426,17 +425,18 @@ class TestClass
 	}
 }";
 
-			Test<LockThisAnalyzer> (input, 1, output);
-		}
+            Analyze<LockThisAnalyzer>(input, output, 1);
+        }
 
-		[Test]
+        [Test] //Breaks my code as when using | does not allow any simple member access expression
+        //I would need to use a BinaryExpressionSyntax to get access to the left/right members. Do I need to make a big recursion code for those cases or just have a simple binary that I would then break in its members to get my hands on the member access expressions and then follow the same logic that I had 
 		public void TestMethodHasSynchronized ()
 		{
 			var input = @"
 using System.Runtime.CompilerServices;
 class TestClass
 {
-	[MethodImpl (MethodImplOptions.Synchronized | MethodImplOptions.NoInlining)]
+	$[MethodImpl (MethodImplOptions.Synchronized | MethodImplOptions.NoInlining)]$
 	void TestMethod ()
 	{
 		System.Console.WriteLine (""Foo"");
@@ -457,10 +457,10 @@ class TestClass
 	}
 }";
 
-			Test<LockThisAnalyzer> (input, 1, output);
-		}
+            Analyze<LockThisAnalyzer>(input, output, 1);
+        }
 
-		[Test]
+        [Test]
 		public void TestMethodNotSynchronized ()
 		{
 			var input = @"
@@ -474,7 +474,7 @@ class TestClass
 	}
 }";
 
-			Test<LockThisAnalyzer> (input, 0);
+			Analyze<LockThisAnalyzer> (input,null,0);
 		}
 
 		[Test]
@@ -484,7 +484,7 @@ class TestClass
 using System.Runtime.CompilerServices;
 abstract class TestClass
 {
-	[MethodImpl (MethodImplOptions.Synchronized)]
+	$[MethodImpl (MethodImplOptions.Synchronized)]$
 	public abstract void TestMethod ();
 }";
 
@@ -495,7 +495,7 @@ abstract class TestClass
 	public abstract void TestMethod ();
 }";
 
-			Test<LockThisAnalyzer> (input, 1, output);
+			Analyze<LockThisAnalyzer> (input, output,1);
 		}
 
 		[Test]
@@ -505,10 +505,10 @@ abstract class TestClass
 using System.Runtime.CompilerServices;
 abstract class TestClass
 {
-	[MethodImpl (MethodImplOptions.Synchronized)]
+	$[MethodImpl (MethodImplOptions.Synchronized)]$
 	public void TestMethod ()
 	{
-		lock (this) {
+		$lock (this)$ {
 		}
 	}
 }";
@@ -527,21 +527,21 @@ abstract class TestClass
 	}
 }";
 
-			Test<LockThisAnalyzer> (input, 2, output, 0);
-		}
+            Analyze<LockThisAnalyzer>(input, output, 2);
+        }
 
-		[Test]
+        [Test]
 		public void TestDelegateLocking ()
 		{
 			var input = @"
 using System.Runtime.CompilerServices;
 abstract class TestClass
 {
-	[MethodImpl (MethodImplOptions.Synchronized)]
+	$[MethodImpl (MethodImplOptions.Synchronized)]$
 	public void TestMethod ()
 	{
 		Action action = delegate {
-			lock (this) {
+			$lock (this)$ {
 			}
 		};
 	}
@@ -563,21 +563,21 @@ abstract class TestClass
 	}
 }";
 
-			Test<LockThisAnalyzer> (input, 2, output, 0);
-		}
+            Analyze<LockThisAnalyzer>(input, output, 2);
+        }
 
-		[Test]
+        [Test]
 		public void TestLambdaLocking ()
 		{
 			var input = @"
 using System.Runtime.CompilerServices;
 abstract class TestClass
 {
-	[MethodImpl (MethodImplOptions.Synchronized)]
+	$[MethodImpl (MethodImplOptions.Synchronized)]$
 	public void TestMethod ()
 	{
 		Action action = () => {
-			lock (this) {
+			$lock (this)$ {
 			}
 		};
 	}
@@ -599,17 +599,17 @@ abstract class TestClass
 	}
 }";
 
-			Test<LockThisAnalyzer> (input, 2, output, 0);
-		}
+            Analyze<LockThisAnalyzer>(input, output, 2);
+        }
 
-		[Test]
+        [Test]
 		public void TestStaticMethod()
 		{
 			var input = @"
 using System.Runtime.CompilerServices;
 class TestClass
 {
-	[MethodImpl (MethodImplOptions.Synchronized)]
+	$[MethodImpl (MethodImplOptions.Synchronized)]$
 	public static void TestMethod ()
 	{
 		Console.WriteLine ();
@@ -629,10 +629,10 @@ class TestClass
 	}
 }";
 
-			Test<LockThisAnalyzer> (input, 1, output);
-		}
+            Analyze<LockThisAnalyzer>(input, output, 1);
+        }
 
-		[Test]
+        [Test]
 		public void TestStaticProperty()
 		{
 			var input = @"
@@ -641,7 +641,7 @@ class TestClass
 {
 	public static int TestProperty
 	{
-		[MethodImpl (MethodImplOptions.Synchronized)]
+		$[MethodImpl (MethodImplOptions.Synchronized)]$
 		set {
 			Console.WriteLine (value);
 		}
@@ -663,23 +663,23 @@ class TestClass
 	}
 }";
 
-			Test<LockThisAnalyzer> (input, 1, output);
-		}
+            Analyze<LockThisAnalyzer>(input, output, 1);
+        }
 
-		[Test]
+        [Test]
 		public void TestMixedStaticMethod()
 		{
 			var input = @"
 using System.Runtime.CompilerServices;
 class TestClass
 {
-	[MethodImpl (MethodImplOptions.Synchronized)]
+	$[MethodImpl (MethodImplOptions.Synchronized)]$
 	public void TestMethod ()
 	{
 		Console.WriteLine ();
 	}
 
-	[MethodImpl (MethodImplOptions.Synchronized)]
+	$[MethodImpl (MethodImplOptions.Synchronized)]$
 	public static void TestStaticMethod ()
 	{
 		Console.WriteLine ();
@@ -705,10 +705,10 @@ class TestClass
 	}
 }";
 
-			Test<LockThisAnalyzer> (input, 2, output, 0);
-		}
+            Analyze<LockThisAnalyzer>(input, output, 2);
+        }
 
-		[Test]
+        [Test]
 		public void TestNewNameLock()
 		{
 			var input = @"
@@ -716,7 +716,7 @@ using System.Runtime.CompilerServices;
 class TestClass
 {
 	int locker;
-	[MethodImpl (MethodImplOptions.Synchronized)]
+	$[MethodImpl (MethodImplOptions.Synchronized)]$
 	public void TestMethod ()
 	{
 		Console.WriteLine ();
@@ -737,7 +737,7 @@ class TestClass
 	}
 }";
 
-			Test<LockThisAnalyzer> (input, 1, output);
-		}
-	}
+            Analyze<LockThisAnalyzer>(input, output, 1);
+        }
+    }
 }

--- a/NR6Pack.Tests/CSharp/Diagnostics/LockThisTests.cs
+++ b/NR6Pack.Tests/CSharp/Diagnostics/LockThisTests.cs
@@ -428,9 +428,8 @@ class TestClass
             Analyze<LockThisAnalyzer>(input, output, 1);
         }
 
-        [Test] //Breaks my code as when using | does not allow any simple member access expression
-        //I would need to use a BinaryExpressionSyntax to get access to the left/right members. Do I need to make a big recursion code for those cases or just have a simple binary that I would then break in its members to get my hands on the member access expressions and then follow the same logic that I had 
-		public void TestMethodHasSynchronized ()
+        [Test]
+        public void TestMethodHasSynchronized ()
 		{
 			var input = @"
 using System.Runtime.CompilerServices;

--- a/NR6Pack.Tests/CSharp/Diagnostics/RewriteIfReturnToReturnTests.cs
+++ b/NR6Pack.Tests/CSharp/Diagnostics/RewriteIfReturnToReturnTests.cs
@@ -1,0 +1,27 @@
+﻿using ICSharpCode.NRefactory6.CSharp.Diagnostics;
+using ICSharpCode.NRefactory6.CSharp.Refactoring;
+using NUnit.Framework;
+
+namespace NR6Pack.Tests.CSharp.Diagnostics
+{
+    [TestFixture]
+    public class RewriteIfReturnToReturnTests : InspectionActionTestBase
+    {
+        [Test]
+        public void When_Return_In_IfStatement()
+        {
+            var input = @"
+class TestClass
+{
+	object TestMethod (object obj)
+	{
+		if(obj != null)
+            return obj;
+        return new object();
+	}
+}";
+
+            Analyze<RewriteIfReturnToReturnAnalyzer>(input, null, 0);
+        }
+    }
+}

--- a/NR6Pack.Tests/NR6Pack.Tests.csproj
+++ b/NR6Pack.Tests/NR6Pack.Tests.csproj
@@ -308,6 +308,7 @@
     <Compile Include="CSharp\Diagnostics\ReplaceWithSingleCallToSingleOrDefaultTests.cs" />
     <Compile Include="CSharp\Diagnostics\ReplaceWithSingleCallToSingleTests.cs" />
     <Compile Include="CSharp\Diagnostics\ReplaceWithStringIsNullOrEmptyTests.cs" />
+    <Compile Include="CSharp\Diagnostics\RewriteIfReturnToReturnTests.cs" />
     <Compile Include="CSharp\Diagnostics\SealedMemberInSealedClassTests.cs" />
     <Compile Include="CSharp\Diagnostics\SimplifyConditionalTernaryExpressionTests.cs" />
     <Compile Include="CSharp\Diagnostics\StaticConstructorParameterTests.cs" />

--- a/NR6Pack/Diagnostics/Custom/LockThisAnalyzer.cs
+++ b/NR6Pack/Diagnostics/Custom/LockThisAnalyzer.cs
@@ -1,20 +1,20 @@
-// LockThisAnalyzer.cs 
-// 
+// LockThisAnalyzer.cs
+//
 // Author:
 //      Luís Reis <luiscubal@gmail.com>
-// 
+//
 // Copyright (c) 2013 Luís Reis <luiscubal@gmail.com>
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in
 // all copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,49 +23,38 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 using System.Collections.Immutable;
-using Microsoft.CodeAnalysis.CodeFixes;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeActions;
-using Microsoft.CodeAnalysis.Text;
-using System.Threading;
-using ICSharpCode.NRefactory6.CSharp.Refactoring;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Linq;
-using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.FindSymbols;
-using System.Runtime.CompilerServices;
 
 namespace ICSharpCode.NRefactory6.CSharp.Diagnostics
 {
-	[DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
     [NotPortedYet]
     public class LockThisAnalyzer : DiagnosticAnalyzer
-	{
-		static readonly DiagnosticDescriptor descriptor = new DiagnosticDescriptor (
-			NRefactoryDiagnosticIDs.LockThisAnalyzerID, 
-			GettextCatalog.GetString("Warns about using lock (this) or MethodImplOptions.Synchronized"),
-			"{0}",
-			DiagnosticAnalyzerCategories.CodeQualityIssues, 
-			DiagnosticSeverity.Warning, 
-			isEnabledByDefault: true,
-			helpLinkUri: HelpLink.CreateFor(NRefactoryDiagnosticIDs.LockThisAnalyzerID)
-		);
+    {
+        private static readonly DiagnosticDescriptor descriptor = new DiagnosticDescriptor(
+            NRefactoryDiagnosticIDs.LockThisAnalyzerID,
+            GettextCatalog.GetString("Warns about using lock (this) or MethodImplOptions.Synchronized"),
+            "Use locking statements with an object for locking",
+            DiagnosticAnalyzerCategories.CodeQualityIssues,
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true,
+            helpLinkUri: HelpLink.CreateFor(NRefactoryDiagnosticIDs.LockThisAnalyzerID)
+        );
 
-        
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor);
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create (descriptor);
         public override void Initialize(AnalysisContext context)
-		{
+        {
             context.RegisterSyntaxNodeAction(
                 (nodeContext) =>
                 {
-                     Diagnostic diagnostic;
+                    Diagnostic diagnostic;
                     if (TryGetDiagnostic(nodeContext, out diagnostic))
                     {
                         nodeContext.ReportDiagnostic(diagnostic);
@@ -73,46 +62,45 @@ namespace ICSharpCode.NRefactory6.CSharp.Diagnostics
                 }, SyntaxKind.LockStatement, SyntaxKind.Attribute);
         }
 
-		static bool TryGetDiagnostic (SyntaxNodeAnalysisContext nodeContext, out Diagnostic diagnostic)
-		{
-			diagnostic = default(Diagnostic);
-			if (nodeContext.IsFromGeneratedCode())
-				return false;
+        private static bool TryGetDiagnostic(SyntaxNodeAnalysisContext nodeContext, out Diagnostic diagnostic)
+        {
+            diagnostic = default(Diagnostic);
+            if (nodeContext.IsFromGeneratedCode())
+                return false;
 
-            var lockStatementThisUsageKeyValuePair = ValidateLockStatementUsesThisExpression(nodeContext);
-            
-            if (lockStatementThisUsageKeyValuePair.Key)
+            if (ValidateLockStatementUsesThisExpression(nodeContext))
             {
-                diagnostic = Diagnostic.Create(descriptor, lockStatementThisUsageKeyValuePair.Value);
+                var lockStatementSyntax = nodeContext.Node as LockStatementSyntax;
+                if (lockStatementSyntax != null)
+                    diagnostic = Diagnostic.Create(descriptor, lockStatementSyntax.LockKeyword.GetLocation());
                 return true;
             }
 
-		    if (!lockStatementThisUsageKeyValuePair.Key)
-		    {
-		        var synchronizedMethodAttributeUsageKeyValuePair =
-		            ValidateMethodImplementationUsesSynchronizedAttribute(nodeContext);
+            var synchronizedMethodAttributeUsageLocation =
+                ValidateMethodImplementationUsesSynchronizedAttribute(nodeContext);
 
-                if (synchronizedMethodAttributeUsageKeyValuePair.Key)
-                {
-                    diagnostic = Diagnostic.Create(descriptor, synchronizedMethodAttributeUsageKeyValuePair.Value);
-                    return true;
-                }
+            if (synchronizedMethodAttributeUsageLocation != null)
+            {
+                diagnostic = Diagnostic.Create(descriptor, synchronizedMethodAttributeUsageLocation);
+                return true;
             }
+
             return false;
         }
 
-        static KeyValuePair<bool,Location> ValidateLockStatementUsesThisExpression(SyntaxNodeAnalysisContext nodeContext)
+        private static bool ValidateLockStatementUsesThisExpression(SyntaxNodeAnalysisContext nodeContext)
         {
             var node = nodeContext.Node as LockStatementSyntax;
             if (node == null)
-                return new KeyValuePair<bool, Location>(false, null);
+                return false;
 
-            return new KeyValuePair<bool, Location>(node
+            return node
                 .ChildNodes()
                 .OfType<ThisExpressionSyntax>()
-                .Any(), node.LockKeyword.GetLocation());
+                .Any();
         }
-        static KeyValuePair<bool, Location> ValidateMethodImplementationUsesSynchronizedAttribute(SyntaxNodeAnalysisContext nodeContext)
+
+        private static Location ValidateMethodImplementationUsesSynchronizedAttribute(SyntaxNodeAnalysisContext nodeContext)
         {
             var attribute = nodeContext.Node as AttributeSyntax;
 
@@ -120,364 +108,410 @@ namespace ICSharpCode.NRefactory6.CSharp.Diagnostics
             {
                 {
                     var attributeArgumentList = attribute.ArgumentList.Arguments;
-                    foreach(var argument in attributeArgumentList)
+                    foreach (var argument in attributeArgumentList)
                     {
                         var memberAccessExpression =
                             argument.ChildNodes().OfType<MemberAccessExpressionSyntax>().FirstOrDefault();
 
-                        if(memberAccessExpression!= null &&
-                           memberAccessExpression
-                               .ChildNodes()
-                               .OfType<IdentifierNameSyntax>()
-                               .First().Identifier.ValueText.Equals("MethodImplOptions") &&
-                           memberAccessExpression.Name.Identifier.ValueText.Equals("Synchronized"))
-
+                        if (memberAccessExpression != null &&
+                        IsSynchronizedEnumValueBeingUsed(memberAccessExpression))
                         {
-                            return new KeyValuePair<bool, Location>(true, memberAccessExpression.GetLocation());
+                            return memberAccessExpression.GetLocation();
+                        }
+
+                        var binaryExpression = argument.ChildNodes().OfType<BinaryExpressionSyntax>().FirstOrDefault();
+
+                        if (memberAccessExpression == null && binaryExpression != null)
+                        {
+                            return FindMemberAccessExpressionLocationWithinBinaryExpression(binaryExpression);
                         }
                     }
                 }
             }
-                return new KeyValuePair<bool, Location>(false, null);
+            return null;
         }
 
-//		class GatherVisitor : GatherVisitorBase<LockThisAnalyzer>
-//		{
-//			public GatherVisitor(SemanticModel semanticModel, Action<Diagnostic> addDiagnostic, CancellationToken cancellationToken)
-//				: base(semanticModel, addDiagnostic, cancellationToken)
-//			{
-//			}
+        private static bool IsSynchronizedEnumValueBeingUsed(MemberAccessExpressionSyntax memberAccessExpression)
+        {
+            return memberAccessExpression
+                .ChildNodes()
+                .OfType<IdentifierNameSyntax>()
+                .First().Identifier.ValueText.Equals("MethodImplOptions") &&
+                   memberAccessExpression.Name.Identifier.ValueText.Equals("Synchronized");
+        }
 
-////			public override void VisitAttribute(Attribute attribute)
-////			{
-////				base.VisitAttribute(attribute);
-////
-////				if (IsMethodSynchronizedAttribute(attribute)) {
-////					var fixAction = new CodeAction(ctx.TranslateString("Create private locker field"), script => {
-////						var containerEntity = GetParentMethodOrProperty(attribute);
-////						var containerType = containerEntity.GetParent<TypeDeclaration>();
-////
-////						FixLockThisIssue(script, containerEntity, containerType);
-////					}, attribute);
-////
-////					AddDiagnosticAnalyzer(new CodeIssue(attribute, ctx.TranslateString("Found [MethodImpl(MethodImplOptions.Synchronized)]"), fixAction));
-////				}
-////			}
-////
-////			static EntityDeclaration GetParentMethodOrProperty(AstNode node)
-////			{
-////				var containerEntity = node.GetParent<EntityDeclaration>();
-////				if (containerEntity is Accessor) {
-////					containerEntity = containerEntity.GetParent<EntityDeclaration>();
-////				}
-////
-////				return containerEntity;
-////			}
-////
-////			public override void VisitLockStatement(LockStatement lockStatement)
-////			{
-////				base.VisitLockStatement(lockStatement);
-////
-////				var expression = lockStatement.Expression;
-////
-////				if (IsThisReference(expression)) {
-////					var fixAction = new CodeAction(ctx.TranslateString("Create private locker field"), script => {
-////						var containerEntity = GetParentMethodOrProperty(lockStatement);
-////
-////						var containerType = containerEntity.GetParent<TypeDeclaration>();
-////
-////						FixLockThisIssue(script, containerEntity, containerType);
-////
-////					}, lockStatement);
-////
-////					AddDiagnosticAnalyzer(new CodeIssue(lockStatement.LockToken.StartLocation,
-////						lockStatement.RParToken.EndLocation, ctx.TranslateString("Found lock (this)"), fixAction));
-////				}
-////			}
-////
-////			static bool IsEntityStatic(EntityDeclaration containerEntity)
-////			{
-////				return containerEntity.Modifiers.HasFlag(Modifiers.Static);
-////			}
-////
-////			void FixLockThisIssue(Script script, EntityDeclaration containerEntity, TypeDeclaration containerType)
-////			{
-////				bool isStatic = IsEntityStatic(containerEntity);
-////
-////				List<BlockStatement> synchronizedStatements = FixMethodsWithMethodImplAttribute(script, containerType, isStatic).ToList();
-////
-////				List<AstNode> linkNodes = new List<AstNode>();
-////
-////				var locksToModify = LocksToModify(containerType, synchronizedStatements);
-////				List<AstNode> nodeContexts = new List<AstNode>(locksToModify);
-////
-////				foreach (var synchronizedStatement in synchronizedStatements) {
-////					if (synchronizedStatement.Statements.Count > 0) {
-////						nodeContexts.Add(synchronizedStatement.Statements.First());
-////
-////						if (!isStatic) {
-////							foreach (var childLock in synchronizedStatement.Descendants.OfType<LockStatement>()) {
-////								if (IsThisReference(childLock.Expression)) {
-////									nodeContexts.Add(childLock);
-////								}
-////							}
-////						}
-////					}
-////				}
-////
-////				string proposedName = GetNameProposal(nodeContexts, "locker");
-////
-////				if (!isStatic) {
-////					foreach (var lockToModify in locksToModify) {
-////						var identifier = new IdentifierExpression (proposedName);
-////						script.Replace(lockToModify.Expression, identifier);
-////
-////						linkNodes.Add(identifier);
-////					}
-////				}
-////
-////				foreach (var synchronizedStatement in synchronizedStatements) {
-////					if (synchronizedStatement.Statements.Count > 0) {
-////						var newBody = synchronizedStatement.Clone();
-////
-////						var outerLock = new LockStatement();
-////						var outerLockIdentifier = new IdentifierExpression (proposedName);
-////						outerLock.Expression = outerLockIdentifier;
-////						outerLock.EmbeddedStatement = newBody;
-////
-////						linkNodes.Add(outerLockIdentifier);
-////
-////						if (!isStatic) {
-////							foreach (var childLock in newBody.Descendants.OfType<LockStatement>()) {
-////								if (IsThisReference(childLock.Expression)) {
-////									var identifier = new IdentifierExpression (proposedName);
-////									childLock.Expression.ReplaceWith(identifier);
-////
-////									linkNodes.Add(identifier);
-////								}
-////							}
-////						}
-////
-////						script.InsertBefore(synchronizedStatement.Statements.First(), outerLock);
-////
-////						foreach (var stmt in synchronizedStatement.Statements) {
-////							script.Remove(stmt);
-////						}
-////					}
-////				}
-////
-////				if (linkNodes.Any()) {
-////					var objectType = new PrimitiveType("object");
-////
-////					var lockerFieldDeclaration = new FieldDeclaration() {
-////						Modifiers = isStatic ? Modifiers.Static : Modifiers.None,
-////						ReturnType = objectType.Clone()
-////					};
-////
-////					var lockerVariable = new VariableInitializer(proposedName, new ObjectCreateExpression(objectType.Clone()));
-////					lockerFieldDeclaration.Variables.Add(lockerVariable);
-////					script.InsertBefore(containerEntity, lockerFieldDeclaration);
-////
-////					linkNodes.Add(lockerVariable.NameToken);
-////
-////					script.Link(linkNodes.ToArray());
-////				}
-////			}
-////
-////			string GetNameProposal(List<AstNode> nodeContexts, string baseName)
-////			{
-////				var resolverStates = nodeContexts.Select(ctx.GetResolverStateBefore).ToList();
-////				string nameProposal;
-////				int n = 0;
-////				do {
-////					nameProposal = baseName + (n == 0 ? string.Empty : n.ToString());
-////					n++;
-////				} while (IdentifierNameExists(resolverStates, nameProposal));
-////				return nameProposal;
-////			}
-////
-////			static bool IdentifierNameExists(List<CSharpResolver> resolverStates, string nameProposal)
-////			{
-////				return resolverStates.Any(resolverState => {
-////					ResolveResult result = resolverState.LookupSimpleNameOrTypeName(nameProposal, new List<IType>(), NameLookupMode.Expression);
-////					return !result.IsError;
-////				});
-////			}
-////
-////			IEnumerable<LockStatement> LocksToModify(TypeDeclaration containerType, IEnumerable<BlockStatement> synchronizedStatements)
-////			{
-////				foreach (var lockToModify in LocksInType(containerType)) {
-////					if (lockToModify.Ancestors.OfType<BlockStatement>()
-////					    .Any(ancestor => synchronizedStatements.Contains(ancestor))) {
-////
-////						//These will be modified separately
-////						continue;
-////					}
-////
-////					if (!IsThisReference (lockToModify.Expression)) {
-////						continue;
-////					}
-////
-////					yield return lockToModify;
-////				}
-////			}
-////
-////			IEnumerable<BlockStatement> FixMethodsWithMethodImplAttribute(Script script, TypeDeclaration containerType, bool isStatic)
-////			{
-////				var bodies = new List<BlockStatement>();
-////
-////				foreach (var entityDeclarationToModify in EntitiesInType(containerType)) {
-////					var methodDeclaration = entityDeclarationToModify as MethodDeclaration;
-////					var accessor = entityDeclarationToModify as Accessor;
-////					if (methodDeclaration == null && accessor == null) {
-////						continue;
-////					}
-////
-////					if ((methodDeclaration != null && IsEntityStatic(methodDeclaration) != isStatic) ||
-////					    (accessor != null && IsEntityStatic(accessor.GetParent<EntityDeclaration>()) != isStatic)) {
-////						//These will need a separate lock and therefore will not be changed.
-////						continue;
-////					}
-////
-////					var attributes = entityDeclarationToModify.Attributes.SelectMany(attributeSection => attributeSection.Attributes);
-////					var methodSynchronizedAttribute = attributes.FirstOrDefault(IsMethodSynchronizedAttribute);
-////					if (methodSynchronizedAttribute != null) {
-////						short methodImplValue = GetMethodImplValue(methodSynchronizedAttribute);
-////						short newValue = (short)(methodImplValue & ~((short)MethodImplOptions.Synchronized));
-////						if (newValue != 0) {
-////							InsertNewAttribute(script, methodSynchronizedAttribute, newValue);
-////						} else {
-////							var section = methodSynchronizedAttribute.GetParent<AttributeSection>();
-////							if (section.Attributes.Count == 1) {
-////								script.Remove(section);
-////							} else {
-////								script.Remove(methodSynchronizedAttribute);
-////							}
-////						}
-////
-////						bool isAbstract = entityDeclarationToModify.Modifiers.HasFlag(Modifiers.Abstract);
-////						if (!isAbstract) {
-////							var body = methodDeclaration == null ? accessor.Body : methodDeclaration.Body;
-////							bodies.Add(body);
-////						}
-////					}
-////				}
-////
-////				return bodies;
-////			}
-////
-////			void InsertNewAttribute(Script script, Attribute attribute, short newValue) {
-////				var availableValues = (MethodImplOptions[]) Enum.GetValues(typeof(MethodImplOptions));
-////				var activeValues = availableValues.Where(value => (newValue & (short)value) != 0).ToList();
-////
-////				var astBuilder = ctx.CreateTypeSystemAstBuilder(attribute);
-////				var methodImplOptionsType = astBuilder.ConvertType(new FullTypeName(typeof(MethodImplOptions).FullName));
-////
-////				Expression expression = CreateMethodImplReferenceNode(activeValues[0], methodImplOptionsType);
-////				for (int optionIndex = 1; optionIndex < activeValues.Count; ++optionIndex) {
-////					expression = new BinaryOperatorExpression(expression,
-////					                                          BinaryOperatorType.BitwiseOr,
-////					                                          CreateMethodImplReferenceNode(activeValues [optionIndex], methodImplOptionsType));
-////				}
-////
-////				var newAttribute = new Attribute();
-////				newAttribute.Type = attribute.Type.Clone();
-////				newAttribute.Arguments.Add(expression);
-////
-////				script.Replace(attribute, newAttribute);
-////			}
-////
-////			static MemberReferenceExpression CreateMethodImplReferenceNode(MethodImplOptions option, AstType methodImplOptionsType)
-////			{
-////				return methodImplOptionsType.Clone().Member(Enum.GetName(typeof(MethodImplOptions), option));
-////			}
-////
-////			bool IsMethodSynchronizedAttribute(Attribute attribute)
-////			{
-////				var unresolvedType = attribute.Type;
-////				var resolvedType = ctx.ResolveType(unresolvedType);
-////
-////				if (resolvedType.FullName != typeof(MethodImplAttribute).FullName) {
-////					return false;
-////				}
-////
-////				short methodImpl = GetMethodImplValue(attribute);
-////
-////				return (methodImpl & (short) MethodImplOptions.Synchronized) != 0;
-////			}
-////
-////			short GetMethodImplValue(Attribute attribute)
-////			{
-////				short methodImpl = 0;
-////				foreach (var argument in attribute.Arguments) {
-////					var namedExpression = argument as NamedExpression;
-////
-////					if (namedExpression == null) {
-////						short? implValue = GetMethodImplOptionsAsShort(argument);
-////
-////						if (implValue != null) {
-////							methodImpl = (short)implValue;
-////						}
-////
-////					} else if (namedExpression.Name == "Value") {
-////						short? implValue = GetMethodImplOptionsAsShort(namedExpression.Expression);
-////
-////						if (implValue != null) {
-////							methodImpl = (short)implValue;
-////						}
-////					}
-////				}
-////
-////				return methodImpl;
-////			}
-////
-////			short? GetMethodImplOptionsAsShort(AstNode argument)
-////			{
-////				//Returns null if the value could not be guessed
-////
-////				var result = ctx.Resolve(argument);
-////				if (!result.IsCompileTimeConstant) {
-////					return null;
-////				}
-////
-////				if (result.Type.FullName == typeof(MethodImplOptions).FullName) {
-////					return (short)(MethodImplOptions)result.ConstantValue;
-////				}
-////
-////				return null;
-////			}
-////
-////			static IEnumerable<EntityDeclaration> EntitiesInType(TypeDeclaration containerType)
-////			{
-////				return containerType.Descendants.OfType<EntityDeclaration>().Where(entityDeclaration => {
-////					var childContainerType = entityDeclaration.GetParent<TypeDeclaration>();
-////
-////					return childContainerType == containerType;
-////				});
-////			}
-////
-////			static IEnumerable<LockStatement> LocksInType(TypeDeclaration containerType)
-////			{
-////				return containerType.Descendants.OfType<LockStatement>().Where(lockStatement => {
-////					var childContainerType = lockStatement.GetParent<TypeDeclaration>();
-////
-////					return childContainerType == containerType;
-////				});
-////			}
-////
-////			static bool IsThisReference (Expression expression)
-////			{
-////				if (expression is ThisReferenceExpression) {
-////					return true;
-////				}
-////
-////				var parenthesizedExpression = expression as ParenthesizedExpression;
-////				if (parenthesizedExpression != null) {
-////					return IsThisReference(parenthesizedExpression.Expression);
-////				}
-////
-////				return false;
-////			}
-//		}
-	}
+        private static Location FindMemberAccessExpressionLocationWithinBinaryExpression(
+            BinaryExpressionSyntax binaryExpression, List<MemberAccessExpressionSyntax> list = null)
+        {
+            if (list == null)
+                list = new List<MemberAccessExpressionSyntax>();
+
+            var leftMember = binaryExpression.Left;
+            var rightMember = binaryExpression.Right;
+
+            #region Recursion
+
+            if (leftMember is BinaryExpressionSyntax)
+            {
+                FindMemberAccessExpressionLocationWithinBinaryExpression((leftMember as BinaryExpressionSyntax), list);
+            }
+
+            if(leftMember is MemberAccessExpressionSyntax)
+                list.Add(leftMember as MemberAccessExpressionSyntax);
+
+            if (rightMember is BinaryExpressionSyntax)
+            {
+                FindMemberAccessExpressionLocationWithinBinaryExpression((rightMember as BinaryExpressionSyntax), list);
+            }
+
+           if(rightMember is MemberAccessExpressionSyntax)
+                list.Add(rightMember as MemberAccessExpressionSyntax);
+
+            #endregion Recursion
+
+            return (from memberAccess 
+                    in list
+                    where IsSynchronizedEnumValueBeingUsed(memberAccess)
+                    select memberAccess.GetLocation()).FirstOrDefault();
+        }
+
+        //		class GatherVisitor : GatherVisitorBase<LockThisAnalyzer>
+        //		{
+        //			public GatherVisitor(SemanticModel semanticModel, Action<Diagnostic> addDiagnostic, CancellationToken cancellationToken)
+        //				: base(semanticModel, addDiagnostic, cancellationToken)
+        //			{
+        //			}
+
+        ////			public override void VisitAttribute(Attribute attribute)
+        ////			{
+        ////				base.VisitAttribute(attribute);
+        ////
+        ////				if (IsMethodSynchronizedAttribute(attribute)) {
+        ////					var fixAction = new CodeAction(ctx.TranslateString("Create private locker field"), script => {
+        ////						var containerEntity = GetParentMethodOrProperty(attribute);
+        ////						var containerType = containerEntity.GetParent<TypeDeclaration>();
+        ////
+        ////						FixLockThisIssue(script, containerEntity, containerType);
+        ////					}, attribute);
+        ////
+        ////					AddDiagnosticAnalyzer(new CodeIssue(attribute, ctx.TranslateString("Found [MethodImpl(MethodImplOptions.Synchronized)]"), fixAction));
+        ////				}
+        ////			}
+        ////
+        ////			static EntityDeclaration GetParentMethodOrProperty(AstNode node)
+        ////			{
+        ////				var containerEntity = node.GetParent<EntityDeclaration>();
+        ////				if (containerEntity is Accessor) {
+        ////					containerEntity = containerEntity.GetParent<EntityDeclaration>();
+        ////				}
+        ////
+        ////				return containerEntity;
+        ////			}
+        ////
+        ////			public override void VisitLockStatement(LockStatement lockStatement)
+        ////			{
+        ////				base.VisitLockStatement(lockStatement);
+        ////
+        ////				var expression = lockStatement.Expression;
+        ////
+        ////				if (IsThisReference(expression)) {
+        ////					var fixAction = new CodeAction(ctx.TranslateString("Create private locker field"), script => {
+        ////						var containerEntity = GetParentMethodOrProperty(lockStatement);
+        ////
+        ////						var containerType = containerEntity.GetParent<TypeDeclaration>();
+        ////
+        ////						FixLockThisIssue(script, containerEntity, containerType);
+        ////
+        ////					}, lockStatement);
+        ////
+        ////					AddDiagnosticAnalyzer(new CodeIssue(lockStatement.LockToken.StartLocation,
+        ////						lockStatement.RParToken.EndLocation, ctx.TranslateString("Found lock (this)"), fixAction));
+        ////				}
+        ////			}
+        ////
+        ////			static bool IsEntityStatic(EntityDeclaration containerEntity)
+        ////			{
+        ////				return containerEntity.Modifiers.HasFlag(Modifiers.Static);
+        ////			}
+        ////
+        ////			void FixLockThisIssue(Script script, EntityDeclaration containerEntity, TypeDeclaration containerType)
+        ////			{
+        ////				bool isStatic = IsEntityStatic(containerEntity);
+        ////
+        ////				List<BlockStatement> synchronizedStatements = FixMethodsWithMethodImplAttribute(script, containerType, isStatic).ToList();
+        ////
+        ////				List<AstNode> linkNodes = new List<AstNode>();
+        ////
+        ////				var locksToModify = LocksToModify(containerType, synchronizedStatements);
+        ////				List<AstNode> nodeContexts = new List<AstNode>(locksToModify);
+        ////
+        ////				foreach (var synchronizedStatement in synchronizedStatements) {
+        ////					if (synchronizedStatement.Statements.Count > 0) {
+        ////						nodeContexts.Add(synchronizedStatement.Statements.First());
+        ////
+        ////						if (!isStatic) {
+        ////							foreach (var childLock in synchronizedStatement.Descendants.OfType<LockStatement>()) {
+        ////								if (IsThisReference(childLock.Expression)) {
+        ////									nodeContexts.Add(childLock);
+        ////								}
+        ////							}
+        ////						}
+        ////					}
+        ////				}
+        ////
+        ////				string proposedName = GetNameProposal(nodeContexts, "locker");
+        ////
+        ////				if (!isStatic) {
+        ////					foreach (var lockToModify in locksToModify) {
+        ////						var identifier = new IdentifierExpression (proposedName);
+        ////						script.Replace(lockToModify.Expression, identifier);
+        ////
+        ////						linkNodes.Add(identifier);
+        ////					}
+        ////				}
+        ////
+        ////				foreach (var synchronizedStatement in synchronizedStatements) {
+        ////					if (synchronizedStatement.Statements.Count > 0) {
+        ////						var newBody = synchronizedStatement.Clone();
+        ////
+        ////						var outerLock = new LockStatement();
+        ////						var outerLockIdentifier = new IdentifierExpression (proposedName);
+        ////						outerLock.Expression = outerLockIdentifier;
+        ////						outerLock.EmbeddedStatement = newBody;
+        ////
+        ////						linkNodes.Add(outerLockIdentifier);
+        ////
+        ////						if (!isStatic) {
+        ////							foreach (var childLock in newBody.Descendants.OfType<LockStatement>()) {
+        ////								if (IsThisReference(childLock.Expression)) {
+        ////									var identifier = new IdentifierExpression (proposedName);
+        ////									childLock.Expression.ReplaceWith(identifier);
+        ////
+        ////									linkNodes.Add(identifier);
+        ////								}
+        ////							}
+        ////						}
+        ////
+        ////						script.InsertBefore(synchronizedStatement.Statements.First(), outerLock);
+        ////
+        ////						foreach (var stmt in synchronizedStatement.Statements) {
+        ////							script.Remove(stmt);
+        ////						}
+        ////					}
+        ////				}
+        ////
+        ////				if (linkNodes.Any()) {
+        ////					var objectType = new PrimitiveType("object");
+        ////
+        ////					var lockerFieldDeclaration = new FieldDeclaration() {
+        ////						Modifiers = isStatic ? Modifiers.Static : Modifiers.None,
+        ////						ReturnType = objectType.Clone()
+        ////					};
+        ////
+        ////					var lockerVariable = new VariableInitializer(proposedName, new ObjectCreateExpression(objectType.Clone()));
+        ////					lockerFieldDeclaration.Variables.Add(lockerVariable);
+        ////					script.InsertBefore(containerEntity, lockerFieldDeclaration);
+        ////
+        ////					linkNodes.Add(lockerVariable.NameToken);
+        ////
+        ////					script.Link(linkNodes.ToArray());
+        ////				}
+        ////			}
+        ////
+        ////			string GetNameProposal(List<AstNode> nodeContexts, string baseName)
+        ////			{
+        ////				var resolverStates = nodeContexts.Select(ctx.GetResolverStateBefore).ToList();
+        ////				string nameProposal;
+        ////				int n = 0;
+        ////				do {
+        ////					nameProposal = baseName + (n == 0 ? string.Empty : n.ToString());
+        ////					n++;
+        ////				} while (IdentifierNameExists(resolverStates, nameProposal));
+        ////				return nameProposal;
+        ////			}
+        ////
+        ////			static bool IdentifierNameExists(List<CSharpResolver> resolverStates, string nameProposal)
+        ////			{
+        ////				return resolverStates.Any(resolverState => {
+        ////					ResolveResult result = resolverState.LookupSimpleNameOrTypeName(nameProposal, new List<IType>(), NameLookupMode.Expression);
+        ////					return !result.IsError;
+        ////				});
+        ////			}
+        ////
+        ////			IEnumerable<LockStatement> LocksToModify(TypeDeclaration containerType, IEnumerable<BlockStatement> synchronizedStatements)
+        ////			{
+        ////				foreach (var lockToModify in LocksInType(containerType)) {
+        ////					if (lockToModify.Ancestors.OfType<BlockStatement>()
+        ////					    .Any(ancestor => synchronizedStatements.Contains(ancestor))) {
+        ////
+        ////						//These will be modified separately
+        ////						continue;
+        ////					}
+        ////
+        ////					if (!IsThisReference (lockToModify.Expression)) {
+        ////						continue;
+        ////					}
+        ////
+        ////					yield return lockToModify;
+        ////				}
+        ////			}
+        ////
+        ////			IEnumerable<BlockStatement> FixMethodsWithMethodImplAttribute(Script script, TypeDeclaration containerType, bool isStatic)
+        ////			{
+        ////				var bodies = new List<BlockStatement>();
+        ////
+        ////				foreach (var entityDeclarationToModify in EntitiesInType(containerType)) {
+        ////					var methodDeclaration = entityDeclarationToModify as MethodDeclaration;
+        ////					var accessor = entityDeclarationToModify as Accessor;
+        ////					if (methodDeclaration == null && accessor == null) {
+        ////						continue;
+        ////					}
+        ////
+        ////					if ((methodDeclaration != null && IsEntityStatic(methodDeclaration) != isStatic) ||
+        ////					    (accessor != null && IsEntityStatic(accessor.GetParent<EntityDeclaration>()) != isStatic)) {
+        ////						//These will need a separate lock and therefore will not be changed.
+        ////						continue;
+        ////					}
+        ////
+        ////					var attributes = entityDeclarationToModify.Attributes.SelectMany(attributeSection => attributeSection.Attributes);
+        ////					var methodSynchronizedAttribute = attributes.FirstOrDefault(IsMethodSynchronizedAttribute);
+        ////					if (methodSynchronizedAttribute != null) {
+        ////						short methodImplValue = GetMethodImplValue(methodSynchronizedAttribute);
+        ////						short newValue = (short)(methodImplValue & ~((short)MethodImplOptions.Synchronized));
+        ////						if (newValue != 0) {
+        ////							InsertNewAttribute(script, methodSynchronizedAttribute, newValue);
+        ////						} else {
+        ////							var section = methodSynchronizedAttribute.GetParent<AttributeSection>();
+        ////							if (section.Attributes.Count == 1) {
+        ////								script.Remove(section);
+        ////							} else {
+        ////								script.Remove(methodSynchronizedAttribute);
+        ////							}
+        ////						}
+        ////
+        ////						bool isAbstract = entityDeclarationToModify.Modifiers.HasFlag(Modifiers.Abstract);
+        ////						if (!isAbstract) {
+        ////							var body = methodDeclaration == null ? accessor.Body : methodDeclaration.Body;
+        ////							bodies.Add(body);
+        ////						}
+        ////					}
+        ////				}
+        ////
+        ////				return bodies;
+        ////			}
+        ////
+        ////			void InsertNewAttribute(Script script, Attribute attribute, short newValue) {
+        ////				var availableValues = (MethodImplOptions[]) Enum.GetValues(typeof(MethodImplOptions));
+        ////				var activeValues = availableValues.Where(value => (newValue & (short)value) != 0).ToList();
+        ////
+        ////				var astBuilder = ctx.CreateTypeSystemAstBuilder(attribute);
+        ////				var methodImplOptionsType = astBuilder.ConvertType(new FullTypeName(typeof(MethodImplOptions).FullName));
+        ////
+        ////				Expression expression = CreateMethodImplReferenceNode(activeValues[0], methodImplOptionsType);
+        ////				for (int optionIndex = 1; optionIndex < activeValues.Count; ++optionIndex) {
+        ////					expression = new BinaryOperatorExpression(expression,
+        ////					                                          BinaryOperatorType.BitwiseOr,
+        ////					                                          CreateMethodImplReferenceNode(activeValues [optionIndex], methodImplOptionsType));
+        ////				}
+        ////
+        ////				var newAttribute = new Attribute();
+        ////				newAttribute.Type = attribute.Type.Clone();
+        ////				newAttribute.Arguments.Add(expression);
+        ////
+        ////				script.Replace(attribute, newAttribute);
+        ////			}
+        ////
+        ////			static MemberReferenceExpression CreateMethodImplReferenceNode(MethodImplOptions option, AstType methodImplOptionsType)
+        ////			{
+        ////				return methodImplOptionsType.Clone().Member(Enum.GetName(typeof(MethodImplOptions), option));
+        ////			}
+        ////
+        ////			bool IsMethodSynchronizedAttribute(Attribute attribute)
+        ////			{
+        ////				var unresolvedType = attribute.Type;
+        ////				var resolvedType = ctx.ResolveType(unresolvedType);
+        ////
+        ////				if (resolvedType.FullName != typeof(MethodImplAttribute).FullName) {
+        ////					return false;
+        ////				}
+        ////
+        ////				short methodImpl = GetMethodImplValue(attribute);
+        ////
+        ////				return (methodImpl & (short) MethodImplOptions.Synchronized) != 0;
+        ////			}
+        ////
+        ////			short GetMethodImplValue(Attribute attribute)
+        ////			{
+        ////				short methodImpl = 0;
+        ////				foreach (var argument in attribute.Arguments) {
+        ////					var namedExpression = argument as NamedExpression;
+        ////
+        ////					if (namedExpression == null) {
+        ////						short? implValue = GetMethodImplOptionsAsShort(argument);
+        ////
+        ////						if (implValue != null) {
+        ////							methodImpl = (short)implValue;
+        ////						}
+        ////
+        ////					} else if (namedExpression.Name == "Value") {
+        ////						short? implValue = GetMethodImplOptionsAsShort(namedExpression.Expression);
+        ////
+        ////						if (implValue != null) {
+        ////							methodImpl = (short)implValue;
+        ////						}
+        ////					}
+        ////				}
+        ////
+        ////				return methodImpl;
+        ////			}
+        ////
+        ////			short? GetMethodImplOptionsAsShort(AstNode argument)
+        ////			{
+        ////				//Returns null if the value could not be guessed
+        ////
+        ////				var result = ctx.Resolve(argument);
+        ////				if (!result.IsCompileTimeConstant) {
+        ////					return null;
+        ////				}
+        ////
+        ////				if (result.Type.FullName == typeof(MethodImplOptions).FullName) {
+        ////					return (short)(MethodImplOptions)result.ConstantValue;
+        ////				}
+        ////
+        ////				return null;
+        ////			}
+        ////
+        ////			static IEnumerable<EntityDeclaration> EntitiesInType(TypeDeclaration containerType)
+        ////			{
+        ////				return containerType.Descendants.OfType<EntityDeclaration>().Where(entityDeclaration => {
+        ////					var childContainerType = entityDeclaration.GetParent<TypeDeclaration>();
+        ////
+        ////					return childContainerType == containerType;
+        ////				});
+        ////			}
+        ////
+        ////			static IEnumerable<LockStatement> LocksInType(TypeDeclaration containerType)
+        ////			{
+        ////				return containerType.Descendants.OfType<LockStatement>().Where(lockStatement => {
+        ////					var childContainerType = lockStatement.GetParent<TypeDeclaration>();
+        ////
+        ////					return childContainerType == containerType;
+        ////				});
+        ////			}
+        ////
+        ////			static bool IsThisReference (Expression expression)
+        ////			{
+        ////				if (expression is ThisReferenceExpression) {
+        ////					return true;
+        ////				}
+        ////
+        ////				var parenthesizedExpression = expression as ParenthesizedExpression;
+        ////				if (parenthesizedExpression != null) {
+        ////					return IsThisReference(parenthesizedExpression.Expression);
+        ////				}
+        ////
+        ////				return false;
+        ////			}
+        //		}
+    }
 }

--- a/NR6Pack/Diagnostics/Custom/LockThisCodeFixProvider.cs
+++ b/NR6Pack/Diagnostics/Custom/LockThisCodeFixProvider.cs
@@ -61,7 +61,8 @@ namespace ICSharpCode.NRefactory6.CSharp.Diagnostics
             var node = root.FindNode(context.Span);
             if (node == null)
                 return;
-            TypeSyntax type = null;
+            var newRoot = root.RemoveNode(node, SyntaxRemoveOptions.KeepNoTrivia);
+            context.RegisterCodeFix(CodeActionFactory.Create(node.Span, diagnostic.Severity, "Use locking statements with an object for locking", document.WithSyntaxRoot(newRoot)), diagnostic);
         }
     }
 }

--- a/NR6Pack/Diagnostics/Custom/LockThisCodeFixProvider.cs
+++ b/NR6Pack/Diagnostics/Custom/LockThisCodeFixProvider.cs
@@ -24,41 +24,44 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CodeFixes;
+using ICSharpCode.NRefactory6.CSharp.CodeRefactorings;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace ICSharpCode.NRefactory6.CSharp.Diagnostics
 {
-	[ExportCodeFixProvider(LanguageNames.CSharp), System.Composition.Shared]
-	public class LockThisCodeFixProvider : CodeFixProvider
-	{
-		public override ImmutableArray<string> FixableDiagnosticIds {
-			get {
-				return ImmutableArray.Create (NRefactoryDiagnosticIDs.LockThisAnalyzerID);
-			}
-		}
+    [ExportCodeFixProvider(LanguageNames.CSharp), System.Composition.Shared]
+    public class LockThisCodeFixProvider : CodeFixProvider
+    {
+        public override ImmutableArray<string> FixableDiagnosticIds
+        {
+            get
+            {
+                return ImmutableArray.Create(NRefactoryDiagnosticIDs.LockThisAnalyzerID);
+            }
+        }
 
-		public override FixAllProvider GetFixAllProvider()
-		{
-			return WellKnownFixAllProviders.BatchFixer;
-		}
+        public override FixAllProvider GetFixAllProvider()
+        {
+            return WellKnownFixAllProviders.BatchFixer;
+        }
 
-		public async override Task RegisterCodeFixesAsync(CodeFixContext context)
-		{
-			var document = context.Document;
-			var cancellationToken = context.CancellationToken;
-			var span = context.Span;
-			var diagnostics = context.Diagnostics;
-			var root = await document.GetSyntaxRootAsync(cancellationToken);
-			var diagnostic = diagnostics.First ();
-			var node = root.FindNode(context.Span);
-			//if (!node.IsKind(SyntaxKind.BaseList))
-			//	continue;
-			var newRoot = root.RemoveNode(node, SyntaxRemoveOptions.KeepNoTrivia);
-			context.RegisterCodeFix(CodeActionFactory.Create(node.Span, diagnostic.Severity, diagnostic.GetMessage(), document.WithSyntaxRoot(newRoot)), diagnostic);
-		}
-	}
+        public async override Task RegisterCodeFixesAsync(CodeFixContext context)
+        {
+            var document = context.Document;
+            var cancellationToken = context.CancellationToken;
+            var span = context.Span;
+            var diagnostics = context.Diagnostics;
+            var root = await document.GetSyntaxRootAsync(cancellationToken);
+            var diagnostic = diagnostics.First();
+            var node = root.FindNode(context.Span);
+            if (node == null)
+                return;
+            TypeSyntax type = null;
+        }
+    }
 }

--- a/NR6Pack/Diagnostics/Synced/Opportunities/RewriteIfReturnToReturnAnalyzer.cs
+++ b/NR6Pack/Diagnostics/Synced/Opportunities/RewriteIfReturnToReturnAnalyzer.cs
@@ -43,7 +43,6 @@ using Microsoft.CodeAnalysis.FindSymbols;
 namespace ICSharpCode.NRefactory6.CSharp.Diagnostics
 {
 	[DiagnosticAnalyzer(LanguageNames.CSharp)]
-    [NotPortedYet]
     public class RewriteIfReturnToReturnAnalyzer : DiagnosticAnalyzer
 	{
 		static readonly DiagnosticDescriptor descriptor = new DiagnosticDescriptor (
@@ -60,26 +59,26 @@ namespace ICSharpCode.NRefactory6.CSharp.Diagnostics
 
 		public override void Initialize(AnalysisContext context)
 		{
-			//context.RegisterSyntaxNodeAction(
-			//	(nodeContext) => {
-			//		Diagnostic diagnostic;
-			//		if (TryGetDiagnostic (nodeContext, out diagnostic)) {
-			//			nodeContext.ReportDiagnostic(diagnostic);
-			//		}
-			//	}, 
-			//	new SyntaxKind[] { SyntaxKind.None }
-			//);
-		}
+            context.RegisterSyntaxNodeAction(
+                (nodeContext) =>
+                {
+                    Diagnostic diagnostic;
+                    if (TryGetDiagnostic(nodeContext, out diagnostic))
+                    {
+                        nodeContext.ReportDiagnostic(diagnostic);
+                    }
+                }, SyntaxKind.IfStatement);
+        }
 
 		static bool TryGetDiagnostic (SyntaxNodeAnalysisContext nodeContext, out Diagnostic diagnostic)
 		{
 			diagnostic = default(Diagnostic);
 			if (nodeContext.IsFromGeneratedCode())
 				return false;
-			//var node = nodeContext.Node as ;
-			//diagnostic = Diagnostic.Create (descriptor, node.GetLocation ());
-			//return true;
-			return false;
+
+		    var node = nodeContext.Node as IfStatementSyntax;
+
+            return node != null && node.ChildNodes().OfType<ReturnStatementSyntax>().Any() ;
 		}
 
 //		class GatherVisitor : GatherVisitorBase<RewriteIfReturnToReturnAnalyzer>


### PR DESCRIPTION
Separated the analyzer in two different code action. It looks and feels more logical to process this way.

TryGetDiagnosticFromLockStatement focuses on lock statement and verifies if the statement inside the lock is of the kind of ThisExpression

TryGetDiagnosticFromPossibleSynchronizeAttribute focuses on attribute syntax. It goes through the attribute syntax to find out if the Synchronized enumeration value was accessed.

The code fix provider was updated.