### PR TITLE
Fix dirty builds all the time from doc file

### DIFF
--- a/ICSharpCode.NRefactory.CSharp/ICSharpCode.NRefactory.CSharp.csproj
+++ b/ICSharpCode.NRefactory.CSharp/ICSharpCode.NRefactory.CSharp.csproj
@@ -18,11 +18,11 @@
     <AssemblyOriginatorKeyFile>..\ICSharpCode.NRefactory.snk</AssemblyOriginatorKeyFile>
     <DelaySign>False</DelaySign>
     <AssemblyOriginatorKeyMode>File</AssemblyOriginatorKeyMode>
-    <DocumentationFile>..\bin\$(Configuration)\ICSharpCode.NRefactory.CSharp.xml</DocumentationFile>
     <NoWarn>1591,1587,1570</NoWarn>
     <OutputPath>..\bin\$(Configuration)\</OutputPath>
     <NoWin32Manifest>False</NoWin32Manifest>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
+    <DocumentationFile>$(IntermediateOutputPath)ICSharpCode.NRefactory.CSharp.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/ICSharpCode.NRefactory.Cecil/ICSharpCode.NRefactory.Cecil.csproj
+++ b/ICSharpCode.NRefactory.Cecil/ICSharpCode.NRefactory.Cecil.csproj
@@ -102,6 +102,7 @@
     <ProjectReference Include="..\..\cecil\Mono.Cecil.csproj">
       <Project>{D68133BD-1E63-496E-9EDE-4FBDBF77B486}</Project>
       <Name>Mono.Cecil</Name>
+      <Private>true</Private>
     </ProjectReference>
   </ItemGroup>
 </Project>

--- a/ICSharpCode.NRefactory.Cecil/ICSharpCode.NRefactory.Cecil.csproj
+++ b/ICSharpCode.NRefactory.Cecil/ICSharpCode.NRefactory.Cecil.csproj
@@ -16,7 +16,7 @@
     <NoStdLib>False</NoStdLib>
     <TreatWarningsAsErrors>False</TreatWarningsAsErrors>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DocumentationFile>..\bin\$(Configuration)\ICSharpCode.NRefactory.Cecil.xml</DocumentationFile>
+    <DocumentationFile>$(IntermediateOutputPath)ICSharpCode.NRefactory.Cecil.xml</DocumentationFile>
     <NoWarn>1591</NoWarn>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/ICSharpCode.NRefactory/ICSharpCode.NRefactory.csproj
+++ b/ICSharpCode.NRefactory/ICSharpCode.NRefactory.csproj
@@ -22,9 +22,9 @@
     <WarningLevel>4</WarningLevel>
     <NoWarn>1591</NoWarn>
     <OutputPath>..\bin\$(Configuration)\</OutputPath>
-    <DocumentationFile>..\bin\$(Configuration)\ICSharpCode.NRefactory.xml</DocumentationFile>
     <NoWin32Manifest>False</NoWin32Manifest>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
+    <DocumentationFile>$(IntermediateOutputPath)ICSharpCode.NRefactory.xml</DocumentationFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Platform)' == 'AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
The previous path of the documentation file, pointed to bin
caused MSBuild on Windows to always build the output assembly
again every time. By moving the doc file to the intermediate
output path, the problem goes away and MSBuild properly
detects that the project is up-to-date.

The doc file is automatically copied to the output path, so
no behavior changes from the previous value.