### PR TITLE
Added option "AlphabeticalSortUsing"

### DIFF
--- a/ICSharpCode.NRefactory.CSharp.Refactoring/CodeActions/SortUsingsAction.cs
+++ b/ICSharpCode.NRefactory.CSharp.Refactoring/CodeActions/SortUsingsAction.cs
@@ -49,7 +49,7 @@ namespace ICSharpCode.NRefactory.CSharp.Refactoring
 				foreach (var block in blocks)
 				{
 					var originalNodes = block.ToArray();
-					var sortedNodes = UsingHelper.SortUsingBlock(originalNodes, context).ToArray();
+					var sortedNodes = UsingHelper.SortUsingBlock(originalNodes, context, script).ToArray();
 
 					for (var i = 0; i < originalNodes.Length; ++i)
 						script.Replace(originalNodes[i], sortedNodes[i].Clone());
@@ -57,7 +57,7 @@ namespace ICSharpCode.NRefactory.CSharp.Refactoring
 			}, usingNode);
 		}
 
-		static AstNode FindUsingNodeAtCursor(RefactoringContext context)
+		private static AstNode FindUsingNodeAtCursor(RefactoringContext context)
 		{
 			// If cursor is inside using declaration
 			var locationAsIs = context.Location;
@@ -71,12 +71,12 @@ namespace ICSharpCode.NRefactory.CSharp.Refactoring
 			return usingNode;
 		}
 
-		static bool IsUsingDeclaration(AstNode node)
+		private static bool IsUsingDeclaration(AstNode node)
 		{
 			return node is UsingDeclaration || node is UsingAliasDeclaration;
 		}
 
-		static IEnumerable<IEnumerable<AstNode>> EnumerateUsingBlocks(AstNode root)
+		private static IEnumerable<IEnumerable<AstNode>> EnumerateUsingBlocks(AstNode root)
 		{
 			var alreadyAddedNodes = new HashSet<AstNode>();
 
@@ -89,7 +89,7 @@ namespace ICSharpCode.NRefactory.CSharp.Refactoring
 				}
 		}
 
-		static IEnumerable<AstNode> EnumerateUsingBlockNodes(AstNode firstNode)
+		private static IEnumerable<AstNode> EnumerateUsingBlockNodes(AstNode firstNode)
 		{
 			for (var node = firstNode; IsUsingDeclaration(node); node = node.GetNextSibling (n => n.Role != Roles.NewLine))
 				yield return node;

--- a/ICSharpCode.NRefactory.CSharp/Formatter/CSharpFormattingOptions.cs
+++ b/ICSharpCode.NRefactory.CSharp/Formatter/CSharpFormattingOptions.cs
@@ -951,6 +951,11 @@ namespace ICSharpCode.NRefactory.CSharp
 			get;
 			set;
 		}
+
+        public bool AlphabeticalSortUsing {
+            get;
+            set;
+        }
 		#endregion
 
 		internal CSharpFormattingOptions()

--- a/ICSharpCode.NRefactory.CSharp/Formatter/FormattingOptionsFactory.cs
+++ b/ICSharpCode.NRefactory.CSharp/Formatter/FormattingOptionsFactory.cs
@@ -174,6 +174,7 @@ namespace ICSharpCode.NRefactory.CSharp
 				MinimumBlankLinesBeforeUsings = 0,
 				MinimumBlankLinesAfterUsings = 1,
 				UsingPlacement = UsingPlacement.TopOfFile,
+                AlphabeticalSortUsing = false,
 				
 				MinimumBlankLinesBeforeFirstDeclaration = 0,
 				MinimumBlankLinesBetweenTypes = 1,


### PR DESCRIPTION
Motivation: my colleagues use Visual Studio with some plugins for refactoring which sort usings in the simple alphabetical order. And NRefactory sort usings by blocks (system usings always first). So to prevent commit wars we need option to make sort in this order.