### PR TITLE
Fixed incorrect null check

### DIFF
--- a/ICSharpCode.NRefactory.CSharp.Refactoring/CodeIssues/Synced/PracticesAndImprovements/ParameterCanBeDeclaredWithBaseTypeIssue.cs
+++ b/ICSharpCode.NRefactory.CSharp.Refactoring/CodeIssues/Synced/PracticesAndImprovements/ParameterCanBeDeclaredWithBaseTypeIssue.cs
@@ -356,7 +356,7 @@ namespace ICSharpCode.NRefactory.CSharp.Refactoring
 			if (localResolveResult == null)
 				return;
 			var resolveResult = context.Resolve(indexerExpression);
-			if (localResolveResult == null)
+			if (resolveResult == null)
 				return;
 			var parent = indexerExpression.Parent;
 			while (parent is ParenthesizedExpression)


### PR DESCRIPTION
localResolveResult was checked twice, but resolveResult null check was skipped.