### PR TITLE
Swap to Cecil from NuGet.

### DIFF
--- a/ICSharpCode.NRefactory.Cecil/CecilLoader.cs
+++ b/ICSharpCode.NRefactory.Cecil/CecilLoader.cs
@@ -293,6 +293,10 @@ namespace ICSharpCode.NRefactory.TypeSystem
 		// used to prevent Cecil from loading referenced assemblies
 		sealed class DummyAssemblyResolver : IAssemblyResolver
 		{
+			public void Dispose ()
+			{
+			}
+
 			public AssemblyDefinition Resolve(AssemblyNameReference name)
 			{
 				return null;
@@ -915,7 +919,8 @@ namespace ICSharpCode.NRefactory.TypeSystem
 					baseTypes.Add(ReadTypeReference(typeDefinition.BaseType));
 				}
 				if (typeDefinition.HasInterfaces) {
-					foreach (TypeReference iface in typeDefinition.Interfaces) {
+					foreach (InterfaceImplementation ii in typeDefinition.Interfaces) {
+						var iface = ii.InterfaceType;
 						baseTypes.Add(ReadTypeReference(iface));
 					}
 				}

--- a/ICSharpCode.NRefactory.Cecil/ICSharpCode.NRefactory.Cecil.csproj
+++ b/ICSharpCode.NRefactory.Cecil/ICSharpCode.NRefactory.Cecil.csproj
@@ -85,6 +85,18 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="Mono.Cecil">
+      <HintPath>..\..\..\packages\Mono.Cecil.0.10.0-beta4\lib\net40\Mono.Cecil.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Mdb">
+      <HintPath>..\..\..\packages\Mono.Cecil.0.10.0-beta4\lib\net40\Mono.Cecil.Mdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Pdb">
+      <HintPath>..\..\..\packages\Mono.Cecil.0.10.0-beta4\lib\net40\Mono.Cecil.Pdb.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Cecil.Rocks">
+      <HintPath>..\..\..\packages\Mono.Cecil.0.10.0-beta4\lib\net40\Mono.Cecil.Rocks.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\ICSharpCode.NRefactory\Properties\GlobalAssemblyInfo.cs">
@@ -99,10 +111,8 @@
       <Project>{3B2A5653-EC97-4001-BB9B-D90F1AF2C371}</Project>
       <Name>ICSharpCode.NRefactory</Name>
     </ProjectReference>
-    <ProjectReference Include="..\..\cecil\Mono.Cecil.csproj">
-      <Project>{D68133BD-1E63-496E-9EDE-4FBDBF77B486}</Project>
-      <Name>Mono.Cecil</Name>
-      <Private>true</Private>
-    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/ICSharpCode.NRefactory.Cecil/packages.config
+++ b/ICSharpCode.NRefactory.Cecil/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Mono.Cecil" version="0.10.0-beta4" targetFramework="net40" />
+</packages>


### PR DESCRIPTION
This is up for discussion. In MonoDevelop, we're switching to Cecil 0.10, and the best option for now is to switch to using NuGet.

See http://cecil.pe/ for breaking changes. I'm assuming that we don't want to handle ownership of AssemblyDefinition/ModuleDefinition, so that falls onto the hands of the user of LoadAssembly/LoadModule APIs